### PR TITLE
feat: Add search functionality with Pagefind

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@11ty/eleventy": "2.0.0",
         "@11ty/eleventy-plugin-rss": "1.2.0",
+        "pagefind": "^1.4.0",
         "rimraf": "5.0.5",
         "shiki": "1.23.1"
       }
@@ -241,6 +242,90 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@pagefind/darwin-arm64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.4.0.tgz",
+      "integrity": "sha512-2vMqkbv3lbx1Awea90gTaBsvpzgRs7MuSgKDxW0m9oV1GPZCZbZBJg/qL83GIUEN2BFlY46dtUZi54pwH+/pTQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/darwin-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.4.0.tgz",
+      "integrity": "sha512-e7JPIS6L9/cJfow+/IAqknsGqEPjJnVXGjpGm25bnq+NPdoD3c/7fAwr1OXkG4Ocjx6ZGSCijXEV4ryMcH2E3A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/freebsd-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.4.0.tgz",
+      "integrity": "sha512-WcJVypXSZ+9HpiqZjFXMUobfFfZZ6NzIYtkhQ9eOhZrQpeY5uQFqNWLCk7w9RkMUwBv1HAMDW3YJQl/8OqsV0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@pagefind/linux-arm64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.4.0.tgz",
+      "integrity": "sha512-PIt8dkqt4W06KGmQjONw7EZbhDF+uXI7i0XtRLN1vjCUxM9vGPdtJc2mUyVPevjomrGz5M86M8bqTr6cgDp1Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/linux-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.4.0.tgz",
+      "integrity": "sha512-z4oddcWwQ0UHrTHR8psLnVlz6USGJ/eOlDPTDYZ4cI8TK8PgwRUPQZp9D2iJPNIPcS6Qx/E4TebjuGJOyK8Mmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/windows-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.4.0.tgz",
+      "integrity": "sha512-NkT+YAdgS2FPCn8mIA9bQhiBs+xmniMGq1LFPDhcFn0+2yIUEiIG06t7bsZlhdjknEQRTSdT7YitP6fC5qwP0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -2250,6 +2335,24 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/pagefind": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.4.0.tgz",
+      "integrity": "sha512-z2kY1mQlL4J8q5EIsQkLzQjilovKzfNVhX8De6oyE6uHpfFtyBaqUpcl/XzJC/4fjD8vBDyh1zolimIcVrCn9g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pagefind": "lib/runner/bin.cjs"
+      },
+      "optionalDependencies": {
+        "@pagefind/darwin-arm64": "1.4.0",
+        "@pagefind/darwin-x64": "1.4.0",
+        "@pagefind/freebsd-x64": "1.4.0",
+        "@pagefind/linux-arm64": "1.4.0",
+        "@pagefind/linux-x64": "1.4.0",
+        "@pagefind/windows-x64": "1.4.0"
+      }
     },
     "node_modules/parse-srcset": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "ELEVENTY_ENV=dev npx eleventy --serve",
     "prebuild": "npm run clean",
     "build": "ELEVENTY_ENV=dev npx eleventy",
-    "build:prod": "ELEVENTY_ENV=prod npx eleventy",
+    "build:prod": "ELEVENTY_ENV=prod npx eleventy && npx pagefind --site dist",
     "debug": "DEBUG=* npx eleventy",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@11ty/eleventy": "2.0.0",
     "@11ty/eleventy-plugin-rss": "1.2.0",
+    "pagefind": "^1.4.0",
     "rimraf": "5.0.5",
     "shiki": "1.23.1"
   }

--- a/src/index.njk
+++ b/src/index.njk
@@ -82,6 +82,7 @@ eleventyExcludeFromCollections: true
           <a href="#catatan">📰 Catatan</a>
           <a href="#karya">🎨 Karya</a>
           <a href="#kontak">💬 Kontak</a>
+          <a href="/search">🔍 Cari</a>
         </nav>
       </div>
     </div>

--- a/src/search.njk
+++ b/src/search.njk
@@ -1,0 +1,79 @@
+---
+title: Cari Artikel
+description: Cari artikel di rizafahmi.com
+eleventyExcludeFromCollections: true
+---
+<!DOCTYPE html>
+<html lang="id">
+<head>
+  <meta charset="UTF-8">
+  <title>{{ title }} - Riza Fahmi</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="{{ description }}">
+  
+  <link rel="stylesheet" href="/assets/global.css">
+  <link rel="stylesheet" href="/assets/home.css">
+  <link href="/pagefind/pagefind-ui.css" rel="stylesheet">
+  
+  <link rel="preload" href="/assets/fonts/wotfard-regular-webfont.woff2" type="font/woff2" as="font" crossorigin="anonymous" />
+  
+  <style>
+    .search-container {
+      max-width: 720px;
+      margin: 0 auto;
+      padding: 2rem 1rem;
+    }
+    .search-header {
+      margin-bottom: 2rem;
+    }
+    .search-header h1 {
+      font-size: 2rem;
+      margin-bottom: 0.5rem;
+    }
+    .search-header p {
+      color: rgba(33, 26, 30, 0.6);
+    }
+    .back-link {
+      display: inline-block;
+      margin-bottom: 1rem;
+      font-size: 1rem;
+    }
+    --pagefind-ui-scale: 1;
+    --pagefind-ui-primary: #211a1e;
+    --pagefind-ui-text: #211a1e;
+    --pagefind-ui-background: #ffffff;
+    --pagefind-ui-border: #eeeeee;
+    --pagefind-ui-tag: #eeeeee;
+  </style>
+</head>
+<body>
+  <div class="search-container">
+    <a class="back-link" href="/">&lt; Kembali</a>
+    
+    <header class="search-header">
+      <h1>🔍 Cari Artikel</h1>
+      <p>Temukan catatan dan artikel yang kamu cari</p>
+    </header>
+    
+    <div id="search"></div>
+  </div>
+  
+  <script src="/pagefind/pagefind-ui.js"></script>
+  <script>
+    new PagefindUI({
+      element: "#search",
+      showSubResults: true,
+      showImages: false,
+      translations: {
+        placeholder: "Ketik untuk mencari...",
+        zero_results: "Tidak ditemukan hasil untuk [SEARCH_TERM]",
+        many_results: "[COUNT] hasil ditemukan",
+        one_result: "1 hasil ditemukan",
+        searching: "Mencari..."
+      }
+    });
+  </script>
+  
+  <script data-goatcounter="https://rizafahmi.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Add client-side search to help visitors find articles quickly.

## Changes
- Install Pagefind for static site search
- Create /search page with Indonesian translations
- Add search link to homepage navigation
- Update build:prod to run Pagefind indexing

## Why Pagefind?
- Built for static sites, indexes at build time
- Tiny bundle (~6kb), works offline
- No external service needed

Closes #62