### PR TITLE
fix: Add focus states for keyboard accessibility

### DIFF
--- a/assets/home.css
+++ b/assets/home.css
@@ -47,9 +47,16 @@
     transition: background 0.2s;
 }
 
-.hero-nav a:hover {
+.hero-nav a:hover,
+.hero-nav a:focus {
     background: #211a1e;
     color: #fff;
+    outline: none;
+}
+
+.hero-nav a:focus-visible {
+    outline: 2px solid #211a1e;
+    outline-offset: 2px;
 }
 
 @media (max-width: 600px) {

--- a/assets/tulisan.css
+++ b/assets/tulisan.css
@@ -135,9 +135,16 @@ small {
     transition: transform 0.2s, box-shadow 0.2s;
 }
 
-.related-card:hover {
+.related-card:hover,
+.related-card:focus {
     transform: translateY(-2px);
     box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+    outline: none;
+}
+
+.related-card:focus-visible {
+    outline: 2px solid #211a1e;
+    outline-offset: 2px;
 }
 
 .related-title {


### PR DESCRIPTION
## Summary
Add missing focus states for keyboard navigation accessibility.

## Changes
- Add :focus and :focus-visible states to hero-nav links (home.css)
- Add :focus and :focus-visible states to related article cards (tulisan.css)

## Why
Keyboard users navigating the site need visual feedback when elements are focused. Previously only hover states were defined.

Closes #80