### PR TITLE
fix: Rename 'Artikel Terkait' to 'Artikel Terbaru'

### DIFF
--- a/src/_includes/tulisan.njk
+++ b/src/_includes/tulisan.njk
@@ -86,10 +86,10 @@ title: Judul
 
       {{ content | safe }}
 
-      <!-- Related Articles -->
+      <!-- Latest Articles -->
       {%- if '/catatan/' in page.url %}
       <section class="related-articles">
-        <h3>📚 Artikel Terkait</h3>
+        <h3>📚 Artikel Terbaru</h3>
         <div class="related-grid">
           {%- set currentUrl = page.url %}
           {%- set count = 0 %}


### PR DESCRIPTION
## Summary
Fix misleading section title in article pages.

## Changes
Rename 'Artikel Terkait' (Related Articles) to 'Artikel Terbaru' (Latest Articles)

## Why
The section displays the most recent articles, not semantically related ones. The title was misleading users into thinking the articles are related to the current content.

Closes #81