### PR TITLE
perf: Optimize latest articles with pre-computed collection

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -45,6 +45,14 @@ module.exports = function (eleventyConfig) {
     return collectionApi.getFilteredByGlob("src/catatan/*.md").filter(item => item.data.date);
   });
 
+  // Pre-computed latest articles for performance (avoids O(N²) in templates)
+  eleventyConfig.addCollection("latestCatatan", function(collectionApi) {
+    return collectionApi.getFilteredByGlob("src/catatan/*.md")
+      .filter(item => item.data.date)
+      .sort((a, b) => b.data.date - a.data.date)
+      .slice(0, 4);
+  });
+
   return {
     dir: { input: "src", output: "dist" },
     dataTemplate: "njk",

--- a/src/_includes/tulisan.njk
+++ b/src/_includes/tulisan.njk
@@ -86,15 +86,14 @@ title: Judul
 
       {{ content | safe }}
 
-      <!-- Related Articles -->
+      <!-- Latest Articles (using pre-computed collection for performance) -->
       {%- if '/catatan/' in page.url %}
       <section class="related-articles">
-        <h3>📚 Artikel Terkait</h3>
+        <h3>📚 Artikel Terbaru</h3>
         <div class="related-grid">
-          {%- set currentUrl = page.url %}
           {%- set count = 0 %}
-          {%- for article in collections.catatan | reverse %}
-            {%- if article.url != currentUrl and count < 3 %}
+          {%- for article in collections.latestCatatan %}
+            {%- if article.url != page.url and count < 3 %}
               <a href="{{ article.url }}" class="related-card">
                 <span class="related-title">{{ article.data.title }}</span>
                 {%- if article.data.created %}


### PR DESCRIPTION
## Summary
Improve build performance by pre-computing the latest articles collection.

## Changes
- Add `latestCatatan` collection in .eleventy.js (pre-sorted, sliced to 4 items)
- Update tulisan.njk to use the pre-computed collection
- Also renamed 'Artikel Terkait' to 'Artikel Terbaru' (fixes #81)

## Why
Previously, the template iterated over the entire catatan collection in reverse for every page render to find 3 articles. This is O(N²) complexity during build. The new approach pre-computes the slice once, reducing to O(N).

Closes #82