### PR TITLE
chore: remove emojis from article titles

### DIFF
--- a/src/catatan/bahasa-fungsional-elixir.md
+++ b/src/catatan/bahasa-fungsional-elixir.md
@@ -1,5 +1,5 @@
 ---
-title: 💧 Berkenalan dengan Bahasa Pemrograman Elixir
+title: Berkenalan dengan Bahasa Pemrograman Elixir
 created: 2024-11-08
 date: 2025-01-10
 layout: tulisan

--- a/src/catatan/digital-garden.md
+++ b/src/catatan/digital-garden.md
@@ -1,5 +1,5 @@
 ---
-title: 🌱 Catatan Tentang Kebun Digital atau Digital Garden
+title: Catatan Tentang Kebun Digital atau Digital Garden
 created: 2024-09-23
 modified: 2024-09-23
 layout: tulisan

--- a/src/catatan/elixir-phoenix-rest-api.md
+++ b/src/catatan/elixir-phoenix-rest-api.md
@@ -1,5 +1,5 @@
 ---
-title: 🌱 Membangun REST API dengan Elixir dan Phoenix
+title: Membangun REST API dengan Elixir dan Phoenix
 created: 2024-09-29
 modified: 2024-09-29
 layout: tulisan

--- a/src/catatan/elixir-struktur-data.md
+++ b/src/catatan/elixir-struktur-data.md
@@ -1,5 +1,5 @@
 ---
-title: 💧 Struktur Data di Bahasa Pemrograman Elixir
+title: Struktur Data di Bahasa Pemrograman Elixir
 created: 2024-12-21
 modified: 2024-12-21
 layout: tulisan

--- a/src/catatan/menemukan-kegunaan-obsidian.md
+++ b/src/catatan/menemukan-kegunaan-obsidian.md
@@ -1,5 +1,5 @@
 ---
-title: 🌱 Akhirnya bisa menemukan kegunaan Obsidian
+title: Akhirnya bisa menemukan kegunaan Obsidian
 created: 2024-09-27
 modified: 2024-09-27
 layout: tulisan

--- a/src/catatan/notebooklm.md
+++ b/src/catatan/notebooklm.md
@@ -1,5 +1,5 @@
 ---
-title: 🪴 Catatan tentang NotebookLM
+title: Catatan tentang NotebookLM
 date: 2024-10-01
 created: 2024-10-01
 layout: tulisan

--- a/src/catatan/paradigma-fungsional-elixir.md
+++ b/src/catatan/paradigma-fungsional-elixir.md
@@ -1,5 +1,5 @@
 ---
-title: 🪴 Konsep Pemrograman Fungsional dengan Elixir
+title: Konsep Pemrograman Fungsional dengan Elixir
 created: 2024-12-30
 modified: 2025-01-06
 layout: tulisan

--- a/src/catatan/paradigma-pemrograman.md
+++ b/src/catatan/paradigma-pemrograman.md
@@ -1,5 +1,5 @@
 ---
-title: 🪴 Catatan Tentang Paradigma Pemrograman
+title: Catatan Tentang Paradigma Pemrograman
 date: 2024-10-01
 created: 2024-09-22
 layout: tulisan

--- a/src/catatan/til-observer-di-proyek-elixir.md
+++ b/src/catatan/til-observer-di-proyek-elixir.md
@@ -1,5 +1,5 @@
 ---
-title: "💡 TIL: Menjalankan Observer di Proyek Elixir"
+title: "TIL: Menjalankan Observer di Proyek Elixir"
 date: 2024-12-03
 created: 2024-12-03
 layout: tulisan

--- a/src/catatan/whisper.cpp.md
+++ b/src/catatan/whisper.cpp.md
@@ -1,5 +1,5 @@
 ---
-title: 🌱 Menggunakan whisper.cpp untuk transkripsi audio
+title: Menggunakan whisper.cpp untuk transkripsi audio
 created: 2024-09-272
 modified: 2024-09-272
 layout: tulisan


### PR DESCRIPTION
Menghapus emoji dari judul artikel sesuai request di issue #93.\n\nChanges:\n- Removed emojis (🌱, 💧, 🪴, 💡) from frontmatter titles in 10 markdown files.\n\nCloses #93