### PR TITLE
refactor: DRY templates with shared partials

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -30,25 +30,6 @@ module.exports = function (eleventyConfig) {
     return minutes + " menit baca";
   });
 
-  eleventyConfig.addFilter("sortDataByDate", (obj) => {
-    const sorted = {};
-    if (obj.date === undefined) {
-      Object.keys(obj)
-        .sort((a, b) => {
-          return obj[a].modified > obj[b].modified ? 1 : -1;
-        })
-        .forEach((name) => (sorted[name] = obj[name]));
-      return sorted;
-    } else {
-      Object.keys(obj)
-        .sort((a, b) => {
-          return obj[a].date > obj[b].date ? 1 : -1;
-        })
-        .forEach((name) => (sorted[name] = obj[name]));
-      return sorted;
-    }
-  });
-
   // Add catatan collection
   eleventyConfig.addCollection("catatan", function(collectionApi) {
     return collectionApi.getFilteredByGlob("src/catatan/*.md").filter(item => item.data.date);

--- a/src/_includes/analytics.njk
+++ b/src/_includes/analytics.njk
@@ -1,0 +1,2 @@
+<script data-goatcounter="https://rizafahmi.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
+<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>

--- a/src/_includes/head.njk
+++ b/src/_includes/head.njk
@@ -1,0 +1,34 @@
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="view-transition" content="same-origin">
+
+<link rel="preload" href="/assets/fonts/wotfard-regular-webfont.woff2" type="font/woff2" as="font" crossorigin="anonymous" />
+
+<meta name="description" content="{{ description or title | escape }}" property="og:description">
+<meta property="og:url" content="https://rizafahmi.com{{ page.url | escape }}" />
+<meta property="og:image" content="https://rizafahmi.com{{ image or "/assets/images/og-twitter.png" }}" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:site" content="@rizafahmi22" />
+<meta name="twitter:title" content="{{ title | escape }}" />
+<meta name="twitter:description" content="{{ description or title | escape }}" />
+<meta name="twitter:image" content="https://rizafahmi.com{{ image or "/assets/images/og-twitter.png" }}">
+
+<link rel="apple-touch-icon" sizes="57x57" href="/assets/images/favico/apple-icon-57x57.png">
+<link rel="apple-touch-icon" sizes="60x60" href="/assets/images/favico/apple-icon-60x60.png">
+<link rel="apple-touch-icon" sizes="72x72" href="/assets/images/favico/apple-icon-72x72.png">
+<link rel="apple-touch-icon" sizes="76x76" href="/assets/images/favico/apple-icon-76x76.png">
+<link rel="apple-touch-icon" sizes="114x114" href="/assets/images/favico/apple-icon-114x114.png">
+<link rel="apple-touch-icon" sizes="120x120" href="/assets/images/favico/apple-icon-120x120.png">
+<link rel="apple-touch-icon" sizes="144x144" href="/assets/images/favico/apple-icon-144x144.png">
+<link rel="apple-touch-icon" sizes="152x152" href="/assets/images/favico/apple-icon-152x152.png">
+<link rel="apple-touch-icon" sizes="180x180" href="/assets/images/favico/apple-icon-180x180.png">
+<link rel="icon" type="image/png" sizes="192x192" href="/assets/images/favico/android-icon-192x192.png">
+<link rel="icon" type="image/png" sizes="32x32" href="/assets/images/favico/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="96x96" href="/assets/images/favico/favicon-96x96.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/assets/images/favico/favicon-16x16.png">
+
+<meta name="msapplication-TileColor" content="#211a1e">
+<meta name="msapplication-TileImage" content="/assets/images/favico/ms-icon-144x144.png">
+<meta name="theme-color" content="#211a1e">
+
+<link rel="alternate" type="application/rss+xml" href="https://rizafahmi.com/feed.xml" />

--- a/src/_includes/main.njk
+++ b/src/_includes/main.njk
@@ -4,76 +4,19 @@ title: Judul
 <!DOCTYPE html>
 <html lang="id">
   <head>
-  <meta charset="UTF-8" />
-  <title>{{ title }}</title>
-  <link rel="preload" as="style" href="/assets/global.css" type="text/css" media="screen" />
-  <link rel="preload" as="style" href="/assets/home.css" type="text/css" media="screen" />
-
-  <link rel="stylesheet" href="/assets/global.css" type="text/css" media="screen" />
-  <link rel="stylesheet" href="/assets/home.css" type="text/css" media="screen" />
-
-  <link rel="preload" href="/assets/fonts/wotfard-regular-webfont.woff2" type="font/woff2" as="font"
-    crossorigin="anonymous" />
-
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="view-transition" content="same-origin">
-  <meta name="description" content="Startup founder, developer, mentor, kreator konten, tukang podcast">
-  <meta property="og:url" content="https://rizafahmi.com{{ page.url | escape }}" />
-  <meta property="og:image" content="https://rizafahmi.com{{ image or "/assets/images/og-twitter.png" }}" />
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:site" content="@rizafahmi22" />
-  <meta name="twitter:title" content="{{ title | escape }}" />
-  <meta name="twitter:description" content="{{ description or title | escape }}" />
-  <meta name="twitter:image" content="https://rizafahmi.com{{ image or "/assets/images/og-twitter.png" }}" />
-
-  <link rel="apple-touch-icon" sizes="57x57" href="/assets/images/favico/apple-icon-57x57.png">
-  <link rel="apple-touch-icon" sizes="60x60" href="/assets/images/favico/apple-icon-60x60.png">
-  <link rel="apple-touch-icon" sizes="72x72" href="/assets/images/favico/apple-icon-72x72.png">
-  <link rel="apple-touch-icon" sizes="76x76" href="/assets/images/favico/apple-icon-76x76.png">
-  <link rel="apple-touch-icon" sizes="114x114" href="/assets/images/favico/apple-icon-114x114.png">
-  <link rel="apple-touch-icon" sizes="120x120" href="/assets/images/favico/apple-icon-120x120.png">
-  <link rel="apple-touch-icon" sizes="144x144" href="/assets/images/favico/apple-icon-144x144.png">
-  <link rel="apple-touch-icon" sizes="152x152" href="/assets/images/favico/apple-icon-152x152.png">
-  <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/favico/apple-icon-180x180.png">
-  <link rel="icon" type="image/png" sizes="192x192" href="/assets/images/favico/android-icon-192x192.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/assets/images/favico/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="96x96" href="/assets/images/favico/favicon-96x96.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/assets/images/favico/favicon-16x16.png">
-  <!-- <link rel="manifest" href="/manifest.json"> -->
-
-  <meta name="msapplication-TileColor" content="#211a1e">
-  <meta name="msapplication-TileImage" content="/assets/images/favico/ms-icon-144x144.png">
-  <meta name="theme-color" content="#211a1e">
-
-  <link rel="alternate" type="application/rss+xml" href="https://rizafahmi.com/feed.xml" />
-</head>
+    <title>{{ title }}</title>
+    <link rel="preload" as="style" href="/assets/global.css" type="text/css" media="screen" />
+    <link rel="preload" as="style" href="/assets/home.css" type="text/css" media="screen" />
+    <link rel="stylesheet" href="/assets/global.css" type="text/css" media="screen" />
+    <link rel="stylesheet" href="/assets/home.css" type="text/css" media="screen" />
+    {% include 'head.njk' %}
+  </head>
   <body>
-      <div style="display: flex; justify-content: space-between; align-items: center;">
-        <h1><a href="/">👋 Saya Riza!</a></h1>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle Dark Mode">🌙</button>
-      </div>
-      {{ content | safe }}
-
-      <script>
-        const toggleBtn = document.getElementById('theme-toggle');
-        const html = document.documentElement;
-        
-        // Check saved theme or system preference
-        const savedTheme = localStorage.getItem('theme');
-        const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-        const initialTheme = savedTheme || systemTheme;
-        
-        html.setAttribute('data-theme', initialTheme);
-        toggleBtn.innerText = initialTheme === 'dark' ? '☀️' : '🌙';
-
-        toggleBtn.addEventListener('click', () => {
-            const currentTheme = html.getAttribute('data-theme');
-            const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-            
-            html.setAttribute('data-theme', newTheme);
-            localStorage.setItem('theme', newTheme);
-            toggleBtn.innerText = newTheme === 'dark' ? '☀️' : '🌙';
-        });
-      </script>
+    <div style="display: flex; justify-content: space-between; align-items: center;">
+      <h1><a href="/">👋 Saya Riza!</a></h1>
+      <button id="theme-toggle" class="theme-toggle" aria-label="Toggle Dark Mode">🌙</button>
+    </div>
+    {{ content | safe }}
+    {% include 'theme-toggle.njk' %}
   </body>
 </html>

--- a/src/_includes/serial.njk
+++ b/src/_includes/serial.njk
@@ -4,71 +4,39 @@ title: Judul
 <!DOCTYPE html>
 <html lang="id">
   <head>
-    <meta charset="UTF-8"/>
     <title>{{ title }}</title>
-
-    <link href="https://unpkg.com/prismjs@1.20.0/themes/prism-okaidia.css" rel="stylesheet">
     <link rel="preload" as="style" href="/assets/global.css" type="text/css" media="screen" />
     <link rel="stylesheet" href="/assets/global.css" type="text/css" media="screen">
     <link rel="preload" as="style" href="/assets/tulisan.css" type="text/css" media="screen" />
     <link rel="stylesheet" href="/assets/tulisan.css" type="text/css" media="screen">
-
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="{{ description or title | escape }}" property="og:description">
-    <meta property="og:url" content="https://rizafahmi.com{{ page.url | escape }}" />
-    <meta property="og:image" content="https://rizafahmi.com{{ image or "/assets/images/og-twitter.png" }}" />
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:site" content="@rizafahmi22" />
-    <meta name="twitter:title" content="{{ title | escape }}" />
-    <meta name="twitter:description" content="{{ description or title | escape }}" />
-    <meta name="twitter:image" content="https://rizafahmi.com{{ image or "/assets/images/og-twitter.png" }}">
-
-    <link rel="preload" href="/assets/fonts/wotfard-regular-webfont.woff2" type="font/woff2" as="font" crossorigin="anonymous" />
-
-    <link rel="apple-touch-icon" sizes="57x57" href="/assets/images/favico/apple-icon-57x57.png">
-    <link rel="apple-touch-icon" sizes="60x60" href="/assets/images/favico/apple-icon-60x60.png">
-    <link rel="apple-touch-icon" sizes="72x72" href="/assets/images/favico/apple-icon-72x72.png">
-    <link rel="apple-touch-icon" sizes="76x76" href="/assets/images/favico/apple-icon-76x76.png">
-    <link rel="apple-touch-icon" sizes="114x114" href="/assets/images/favico/apple-icon-114x114.png">
-    <link rel="apple-touch-icon" sizes="120x120" href="/assets/images/favico/apple-icon-120x120.png">
-    <link rel="apple-touch-icon" sizes="144x144" href="/assets/images/favico/apple-icon-144x144.png">
-    <link rel="apple-touch-icon" sizes="152x152" href="/assets/images/favico/apple-icon-152x152.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/favico/apple-icon-180x180.png">
-    <link rel="icon" type="image/png" sizes="192x192"  href="/assets/images/favico/android-icon-192x192.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="/assets/images/favico/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="96x96" href="/assets/images/favico/favicon-96x96.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/assets/images/favico/favicon-16x16.png">
-    <!-- <link rel="manifest" href="/manifest.json"> -->
-
-    <meta name="msapplication-TileColor" content="#211a1e">
-    <meta name="msapplication-TileImage" content="/assets/images/favico/ms-icon-144x144.png">
-    <meta name="theme-color" content="#211a1e">
-    <link rel="alternate" type="application/rss+xml" href="https://rizafahmi.com/feed.xml" />
+    {% include 'head.njk' %}
   </head>
   <body>
+    <div style="display: flex; justify-content: space-between; align-items: center;">
       {% include 'back_button.njk' %}
+      <button id="theme-toggle" class="theme-toggle" aria-label="Toggle Dark Mode" style="background:none; border:none; cursor:pointer; font-size:1.5rem;">🌙</button>
+    </div>
 
-      <h2>{{ title }}</h2>
+    <h2>{{ title }}</h2>
 
-      <small>Bagian dari serial tentang <span class="tags">{{tags}}</span></h3>
+    <small>Bagian dari serial tentang <span class="tags">{{tags}}</span></h3>
 
-      {{ content | safe }}
+    {{ content | safe }}
 
-      <hr />
+    <hr />
 
-      <a class="back" href="/">&lt; Kembali ke halaman utama</a>
+    <a class="back" href="/">&lt; Kembali ke halaman utama</a>
 
-      <script src="https://utteranc.es/client.js"
-        repo="rizafahmi/rizafahmi.com"
-        issue-term="pathname"
-        label="💬 Comment"
-        theme="github-light"
-        crossorigin="anonymous"
-        async>
-      </script>
+    <script src="https://utteranc.es/client.js"
+      repo="rizafahmi/rizafahmi.com"
+      issue-term="pathname"
+      label="💬 Comment"
+      theme="github-light"
+      crossorigin="anonymous"
+      async>
+    </script>
 
-      <script data-goatcounter="https://rizafahmi.goatcounter.com/count"
-        async src="//gc.zgo.at/count.js"></script>
-      <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+    {% include 'analytics.njk' %}
+    {% include 'theme-toggle.njk' %}
   </body>
 </html>

--- a/src/_includes/theme-toggle.njk
+++ b/src/_includes/theme-toggle.njk
@@ -1,0 +1,21 @@
+<script>
+  const toggleBtn = document.getElementById('theme-toggle');
+  const html = document.documentElement;
+  
+  const savedTheme = localStorage.getItem('theme');
+  const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  const initialTheme = savedTheme || systemTheme;
+  
+  html.setAttribute('data-theme', initialTheme);
+  if (toggleBtn) {
+    toggleBtn.innerText = initialTheme === 'dark' ? '☀️' : '🌙';
+    toggleBtn.addEventListener('click', () => {
+      const currentTheme = html.getAttribute('data-theme');
+      const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+      
+      html.setAttribute('data-theme', newTheme);
+      localStorage.setItem('theme', newTheme);
+      toggleBtn.innerText = newTheme === 'dark' ? '☀️' : '🌙';
+    });
+  }
+</script>

--- a/src/_includes/tulisan.njk
+++ b/src/_includes/tulisan.njk
@@ -4,47 +4,12 @@ title: Judul
 <!DOCTYPE html>
 <html lang="id">
   <head>
-    <meta charset="UTF-8"/>
     <title>{{ title }} - Halo, Saya Riza!</title>
-
-    <link href="https://unpkg.com/prismjs@1.20.0/themes/prism-okaidia.css" rel="stylesheet">
     <link rel="preload" as="style" href="/assets/global.css" type="text/css" media="screen" />
     <link rel="stylesheet" href="/assets/global.css" type="text/css" media="screen">
     <link rel="preload" as="style" href="/assets/tulisan.css" type="text/css" media="screen" />
     <link rel="stylesheet" href="/assets/tulisan.css" type="text/css" media="screen">
-
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="view-transition" content="same-origin">
-    <meta name="description" content="{{ description or title | escape }}" property="og:description">
-    <meta property="og:url" content="https://rizafahmi.com{{ page.url | escape }}" />
-    <meta property="og:image" content="https://rizafahmi.com{{ image or "/assets/images/og-twitter.png" }}" />
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:site" content="@rizafahmi22" />
-    <meta name="twitter:title" content="{{ title | escape }}" />
-    <meta name="twitter:description" content="{{ description or title | escape }}" />
-    <meta name="twitter:image" content="https://rizafahmi.com{{ image or "/assets/images/og-twitter.png" }}">
-
-    <link rel="preload" href="/assets/fonts/wotfard-regular-webfont.woff2" type="font/woff2" as="font" crossorigin="anonymous" />
-
-    <link rel="apple-touch-icon" sizes="57x57" href="/assets/images/favico/apple-icon-57x57.png">
-    <link rel="apple-touch-icon" sizes="60x60" href="/assets/images/favico/apple-icon-60x60.png">
-    <link rel="apple-touch-icon" sizes="72x72" href="/assets/images/favico/apple-icon-72x72.png">
-    <link rel="apple-touch-icon" sizes="76x76" href="/assets/images/favico/apple-icon-76x76.png">
-    <link rel="apple-touch-icon" sizes="114x114" href="/assets/images/favico/apple-icon-114x114.png">
-    <link rel="apple-touch-icon" sizes="120x120" href="/assets/images/favico/apple-icon-120x120.png">
-    <link rel="apple-touch-icon" sizes="144x144" href="/assets/images/favico/apple-icon-144x144.png">
-    <link rel="apple-touch-icon" sizes="152x152" href="/assets/images/favico/apple-icon-152x152.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/favico/apple-icon-180x180.png">
-    <link rel="icon" type="image/png" sizes="192x192"  href="/assets/images/favico/android-icon-192x192.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="/assets/images/favico/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="96x96" href="/assets/images/favico/favicon-96x96.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/assets/images/favico/favicon-16x16.png">
-    <!-- <link rel="manifest" href="/manifest.json"> -->
-
-    <meta name="msapplication-TileColor" content="#211a1e">
-    <meta name="msapplication-TileImage" content="/assets/images/favico/ms-icon-144x144.png">
-    <meta name="theme-color" content="#211a1e">
-    <link rel="alternate" type="application/rss+xml" href="https://rizafahmi.com/feed.xml" />
+    {% include 'head.njk' %}
 
     <script type="application/ld+json">
     {
@@ -73,8 +38,8 @@ title: Judul
   <body>
     <div class="container">
       <div style="display: flex; justify-content: space-between; align-items: center;">
-      {% include 'back_button.njk' %}
-      <button id="theme-toggle" class="theme-toggle" aria-label="Toggle Dark Mode" style="background:none; border:none; cursor:pointer; font-size:1.5rem;">🌙</button>
+        {% include 'back_button.njk' %}
+        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle Dark Mode" style="background:none; border:none; cursor:pointer; font-size:1.5rem;">🌙</button>
       </div>
 
       <h2>{{ title }}</h2>
@@ -93,7 +58,6 @@ title: Judul
 
       {{ content | safe }}
 
-      <!-- Latest Articles (using pre-computed collection for performance) -->
       {%- if '/catatan/' in page.url %}
       <section class="related-articles">
         <h3>📚 Artikel Lainnya</h3>
@@ -129,33 +93,7 @@ title: Judul
       </script>
       {%- endif %}
 
-
-
-
-      <script data-goatcounter="https://rizafahmi.goatcounter.com/count"
-        async src="//gc.zgo.at/count.js"></script>
-      <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-  <script>
-        const toggleBtn = document.getElementById('theme-toggle');
-        const html = document.documentElement;
-        
-        // Check saved theme or system preference
-        const savedTheme = localStorage.getItem('theme');
-        const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-        const initialTheme = savedTheme || systemTheme;
-        
-        html.setAttribute('data-theme', initialTheme);
-        if (toggleBtn) {
-            toggleBtn.innerText = initialTheme === 'dark' ? '☀️' : '🌙';
-            toggleBtn.addEventListener('click', () => {
-                const currentTheme = html.getAttribute('data-theme');
-                const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-                
-                html.setAttribute('data-theme', newTheme);
-                localStorage.setItem('theme', newTheme);
-                toggleBtn.innerText = newTheme === 'dark' ? '☀️' : '🌙';
-            });
-        }
-      </script>
+      {% include 'analytics.njk' %}
+      {% include 'theme-toggle.njk' %}
   </body>
 </html>

--- a/src/index.njk
+++ b/src/index.njk
@@ -6,50 +6,12 @@ eleventyExcludeFromCollections: true
 <html lang="id">
 
 <head>
-  <meta charset="UTF-8" />
   <title>{{ title }}</title>
   <link rel="preload" as="style" href="/assets/global.css" type="text/css" media="screen" />
   <link rel="preload" as="style" href="/assets/home.css" type="text/css" media="screen" />
-
   <link rel="stylesheet" href="/assets/global.css" type="text/css" media="screen" />
   <link rel="stylesheet" href="/assets/home.css" type="text/css" media="screen" />
-
-  <link rel="preload" href="/assets/fonts/wotfard-regular-webfont.woff2" type="font/woff2" as="font"
-    crossorigin="anonymous" />
-
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="view-transition" content="same-origin">
-
-  <meta name="description" content="{{ description or title | escape }}" property="og:description">
-  <meta property="og:url" content="https://rizafahmi.com{{ page.url | escape }}" />
-  <meta property="og:image" content="https://rizafahmi.com{{ image or "/assets/images/og-twitter.png" }}" />
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:site" content="@rizafahmi22" />
-  <meta name="twitter:title" content="{{ title | escape }}" />
-  <meta name="twitter:description" content="{{ description or title | escape }}" />
-  <meta name="twitter:image" content="https://rizafahmi.com{{ image or "/assets/images/og-twitter.png" }}">
-
-  <link rel="apple-touch-icon" sizes="57x57" href="/assets/images/favico/apple-icon-57x57.png">
-  <link rel="apple-touch-icon" sizes="60x60" href="/assets/images/favico/apple-icon-60x60.png">
-  <link rel="apple-touch-icon" sizes="72x72" href="/assets/images/favico/apple-icon-72x72.png">
-  <link rel="apple-touch-icon" sizes="76x76" href="/assets/images/favico/apple-icon-76x76.png">
-  <link rel="apple-touch-icon" sizes="114x114" href="/assets/images/favico/apple-icon-114x114.png">
-  <link rel="apple-touch-icon" sizes="120x120" href="/assets/images/favico/apple-icon-120x120.png">
-  <link rel="apple-touch-icon" sizes="144x144" href="/assets/images/favico/apple-icon-144x144.png">
-  <link rel="apple-touch-icon" sizes="152x152" href="/assets/images/favico/apple-icon-152x152.png">
-  <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/favico/apple-icon-180x180.png">
-  <link rel="icon" type="image/png" sizes="192x192" href="/assets/images/favico/android-icon-192x192.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/assets/images/favico/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="96x96" href="/assets/images/favico/favicon-96x96.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/assets/images/favico/favicon-16x16.png">
-  <!-- <link rel="manifest" href="/manifest.json"> -->
-
-
-  <meta name="msapplication-TileColor" content="#211a1e">
-  <meta name="msapplication-TileImage" content="/assets/images/favico/ms-icon-144x144.png">
-  <meta name="theme-color" content="#211a1e">
-
-  <link rel="alternate" type="application/rss+xml" href="https://rizafahmi.com/feed.xml" />
+  {% include 'head.njk' %}
 
   <script type="application/ld+json">
   {
@@ -373,28 +335,9 @@ eleventyExcludeFromCollections: true
 
   <script data-goatcounter="https://rizafahmi.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
 
+  {% include 'theme-toggle.njk' %}
+
   <script>
-    // Dark Mode Logic
-    const toggleBtn = document.getElementById('theme-toggle');
-    const html = document.documentElement;
-    
-    // Check saved theme or system preference
-    const savedTheme = localStorage.getItem('theme');
-    const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    const initialTheme = savedTheme || systemTheme;
-    
-    html.setAttribute('data-theme', initialTheme);
-    toggleBtn.innerText = initialTheme === 'dark' ? '☀️' : '🌙';
-
-    toggleBtn.addEventListener('click', () => {
-        const currentTheme = html.getAttribute('data-theme');
-        const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-        
-        html.setAttribute('data-theme', newTheme);
-        localStorage.setItem('theme', newTheme);
-        toggleBtn.innerText = newTheme === 'dark' ? '☀️' : '🌙';
-    });
-
     // Typewriter Logic
     const text = "Sedang menulis artikel tentang cara kerja coding agent. Sementara bisa diintip di github.com/rizafahmi/mbb/issues";
     const typewriterElement = document.getElementById('typewriter');

--- a/src/search.njk
+++ b/src/search.njk
@@ -6,16 +6,11 @@ eleventyExcludeFromCollections: true
 <!DOCTYPE html>
 <html lang="id">
 <head>
-  <meta charset="UTF-8">
   <title>{{ title }} - Riza Fahmi</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="{{ description }}">
-  
   <link rel="stylesheet" href="/assets/global.css">
   <link rel="stylesheet" href="/assets/home.css">
   <link href="/pagefind/pagefind-ui.css" rel="stylesheet">
-  
-  <link rel="preload" href="/assets/fonts/wotfard-regular-webfont.woff2" type="font/woff2" as="font" crossorigin="anonymous" />
+  {% include 'head.njk' %}
   
   <style>
     .search-container {
@@ -58,8 +53,8 @@ eleventyExcludeFromCollections: true
 <body>
   <div class="search-container">
     <div style="display: flex; justify-content: space-between; align-items: center;">
-    <a class="back-link" href="/">&lt; Kembali</a>
-    <button id="theme-toggle" class="theme-toggle" aria-label="Toggle Dark Mode" style="background:none; border:none; cursor:pointer; font-size:1.5rem;">🌙</button>
+      <a class="back-link" href="/">&lt; Kembali</a>
+      <button id="theme-toggle" class="theme-toggle" aria-label="Toggle Dark Mode" style="background:none; border:none; cursor:pointer; font-size:1.5rem;">🌙</button>
     </div>
     
     <header class="search-header">
@@ -87,27 +82,6 @@ eleventyExcludeFromCollections: true
   </script>
   
   <script data-goatcounter="https://rizafahmi.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
-<script>
-    const toggleBtn = document.getElementById('theme-toggle');
-    const html = document.documentElement;
-    
-    // Check saved theme or system preference
-    const savedTheme = localStorage.getItem('theme');
-    const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    const initialTheme = savedTheme || systemTheme;
-    
-    html.setAttribute('data-theme', initialTheme);
-    if (toggleBtn) {
-        toggleBtn.innerText = initialTheme === 'dark' ? '☀️' : '🌙';
-        toggleBtn.addEventListener('click', () => {
-            const currentTheme = html.getAttribute('data-theme');
-            const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-            
-            html.setAttribute('data-theme', newTheme);
-            localStorage.setItem('theme', newTheme);
-            toggleBtn.innerText = newTheme === 'dark' ? '☀️' : '🌙';
-        });
-    }
-  </script>
+  {% include 'theme-toggle.njk' %}
 </body>
 </html>


### PR DESCRIPTION
- Extract shared head.njk for meta tags, favicons, and common head elements
- Extract theme-toggle.njk for dark mode toggle script
- Extract analytics.njk for GoatCounter and Twitter scripts
- Remove unused sortDataByDate filter (YAGNI)
- Remove unused PrismJS CSS (using Shiki instead)
- Add missing theme toggle to serial.njk

Reduces ~150+ lines of duplicated code across templates.

Amp-Thread-ID: https://ampcode.com/threads/T-019c2dcd-a3da-74ea-b529-65282021096c