### PR TITLE
SEO/social: better meta descriptions + OG image fallback

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -59,6 +59,17 @@ export default function (eleventyConfig) {
     return minutes + " menit baca";
   });
 
+  // Plain-text excerpt for meta description (social previews, SEO).
+  eleventyConfig.addFilter("excerpt", (content, length = 180) => {
+    if (!content) return "";
+    const text = content
+      .replace(/<[^>]*>/g, " ")
+      .replace(/\s+/g, " ")
+      .trim();
+    if (text.length <= length) return text;
+    return text.slice(0, length).replace(/\s+\S*$/, "") + "…";
+  });
+
   eleventyConfig.addCollection("catatan", function(collectionApi) {
     return collectionApi.getFilteredByGlob("src/catatan/*.md").filter(item => item.data.date);
   });

--- a/src/_includes/head.njk
+++ b/src/_includes/head.njk
@@ -5,14 +5,22 @@
 
 <link rel="preload" href="/assets/fonts/wotfard-regular-webfont.woff2" type="font/woff2" as="font" crossorigin="anonymous" />
 
-<meta name="description" content="{{ description or title | escape }}" property="og:description">
+{# --- Social + SEO helpers --- #}
+{%- set _desc = description or (content | excerpt(180)) or title -%}
+{%- set _ogPath = image or cover or "/assets/images/og-twitter.png" -%}
+{%- if _ogPath and _ogPath.startsWith('./') -%}
+  {%- set _ogPath = page.url + (_ogPath | replace('./', '')) -%}
+{%- endif -%}
+
+<link rel="canonical" href="https://rizafahmi.com{{ page.url | escape }}" />
+<meta name="description" content="{{ _desc | escape }}" property="og:description">
 <meta property="og:url" content="https://rizafahmi.com{{ page.url | escape }}" />
-<meta property="og:image" content="https://rizafahmi.com{{ image or "/assets/images/og-twitter.png" }}" />
+<meta property="og:image" content="https://rizafahmi.com{{ _ogPath }}" />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:site" content="@rizafahmi22" />
 <meta name="twitter:title" content="{{ title | escape }}" />
-<meta name="twitter:description" content="{{ description or title | escape }}" />
-<meta name="twitter:image" content="https://rizafahmi.com{{ image or "/assets/images/og-twitter.png" }}">
+<meta name="twitter:description" content="{{ _desc | escape }}" />
+<meta name="twitter:image" content="https://rizafahmi.com{{ _ogPath }}">
 
 <link rel="apple-touch-icon" sizes="57x57" href="/assets/images/favico/apple-icon-57x57.png">
 <link rel="apple-touch-icon" sizes="60x60" href="/assets/images/favico/apple-icon-60x60.png">


### PR DESCRIPTION
Perbaikan untuk jalur social (X/LinkedIn) → blog:

- Tambah filter `excerpt` untuk bikin meta description otomatis dari konten (fallback kalau frontmatter `description` kosong).
- Update meta tags di `src/_includes/head.njk`:
  - tambah canonical link
  - og/twitter description pakai excerpt
  - og/twitter image fallback pakai `image` atau `cover` (support cover relatif `./...` → `page.url/...`)

Tujuan: preview saat share lebih menarik & konsisten tanpa harus isi frontmatter satu-satu.
