### PR TITLE
feat: add curated topic hub pages (/topik)

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -52,6 +52,7 @@ eleventyExcludeFromCollections: true
 
         <nav class="hero-nav">
           <a href="#catatan">📰 Catatan</a>
+          <a href="/topik/">🧭 Mulai</a>
           <a href="/tags">🏷️ Topik</a>
           <a href="#karya">🎨 Karya</a>
           <a href="#kontak">💬 Kontak</a>

--- a/src/topik/ai.njk
+++ b/src/topik/ai.njk
@@ -1,0 +1,34 @@
+---
+title: "AI & Agentic Coding"
+layout: main
+permalink: "/topik/ai/"
+---
+
+<main>
+  <h2>AI & Agentic Coding</h2>
+  <p style="color: var(--meta-color); margin-top: -0.5rem; font-size: 0.95rem;">
+    Kurasi tulisan untuk memahami AI yang praktis (dan sedikit agentic).
+  </p>
+
+  <h3 style="margin-top: 1.5rem;">Mulai dari sini</h3>
+  <div class="articles">
+    <div class="article"><a href="/catatan/asisten-ngoding"><h6>&gt;&nbsp;&nbsp; Produktif dengan Asisten Ngoding</h6></a></div>
+    <div class="article"><a href="/catatan/asisten-ngoding-2"><h6>&gt;&nbsp;&nbsp; Diskusi dan Menulis Spesifikasi dengan AI</h6></a></div>
+    <div class="article"><a href="/catatan/asisten-ngoding-3"><h6>&gt;&nbsp;&nbsp; Menyusun Rencana dengan Asisten Ngoding</h6></a></div>
+    <div class="article"><a href="/catatan/asisten-ngoding-4"><h6>&gt;&nbsp;&nbsp; Desain Antarmuka dengan Asisten Ngoding</h6></a></div>
+    <div class="article"><a href="/catatan/asisten-ngoding-5"><h6>&gt;&nbsp;&nbsp; Menulis Kode dengan Asisten Ngoding</h6></a></div>
+  </div>
+
+  <h3 style="margin-top: 1.5rem;">Tools & catatan</h3>
+  <div class="articles">
+    <div class="article"><a href="/catatan/notebooklm"><h6>&gt;&nbsp;&nbsp; NotebookLM</h6></a></div>
+    <div class="article"><a href="/catatan/whisper.cpp"><h6>&gt;&nbsp;&nbsp; whisper.cpp</h6></a></div>
+    <div class="article"><a href="/gemini-web-dev/"><h6>&gt;&nbsp;&nbsp; Gemini untuk Web Developer</h6></a></div>
+  </div>
+
+  <p style="font-size: 0.9rem; color: var(--meta-color);">
+    Lihat juga: <a href="/tags/ai/">Topik: ai</a> · <a href="/tags/agentic-coding/">Topik: agentic-coding</a>
+  </p>
+
+  <a class="back" href="/topik/">&lt; Semua topik pilihan</a>
+</main>

--- a/src/topik/elixir.njk
+++ b/src/topik/elixir.njk
@@ -1,0 +1,31 @@
+---
+title: "Elixir, OTP, dan Functional Programming"
+layout: main
+permalink: "/topik/elixir/"
+---
+
+<main>
+  <h2>Elixir, OTP, dan Functional Programming</h2>
+  <p style="color: var(--meta-color); margin-top: -0.5rem; font-size: 0.95rem;">
+    Kurasi tulisan untuk kamu yang ingin memahami Elixir/OTP + mindset FP.
+  </p>
+
+  <h3 style="margin-top: 1.5rem;">Mulai dari sini</h3>
+  <div class="articles">
+    <div class="article"><a href="/catatan/bahasa-fungsional-elixir"><h6>&gt;&nbsp;&nbsp; Berkenalan dengan Bahasa Pemrograman Elixir</h6></a></div>
+    <div class="article"><a href="/2019/04/29/memahami-beam/"><h6>&gt;&nbsp;&nbsp; Memahami Sistem Konkurensi BEAM Melalui Elixir</h6></a></div>
+    <div class="article"><a href="/catatan/til-observer-di-proyek-elixir"><h6>&gt;&nbsp;&nbsp; TIL: Observer di Proyek Elixir</h6></a></div>
+  </div>
+
+  <h3 style="margin-top: 1.5rem;">Build sesuatu</h3>
+  <div class="articles">
+    <div class="article"><a href="/catatan/elixir-phoenix-rest-api/"><h6>&gt;&nbsp;&nbsp; Membangun REST API dengan Elixir dan Phoenix</h6></a></div>
+    <div class="article"><a href="/catatan/membangun-permainan-balap-kode-dgn-ai/"><h6>&gt;&nbsp;&nbsp; Membangun Permainan Balap Kode dengan AI</h6></a></div>
+  </div>
+
+  <p style="font-size: 0.9rem; color: var(--meta-color);">
+    Lihat juga: <a href="/tags/elixir/">Topik: elixir</a> · <a href="/tags/otp/">Topik: otp</a>
+  </p>
+
+  <a class="back" href="/topik/">&lt; Semua topik pilihan</a>
+</main>

--- a/src/topik/index.njk
+++ b/src/topik/index.njk
@@ -1,0 +1,24 @@
+---
+title: Topik Pilihan
+layout: main
+---
+
+<main>
+  <h2>Topik Pilihan</h2>
+  <p style="color: var(--meta-color); margin-top: -0.5rem; font-size: 0.95rem;">
+    Halaman kurasi untuk pembaca baru. Cocok buat kamu share dari X/LinkedIn.
+  </p>
+
+  <div class="articles">
+    <div class="article"><a href="/topik/ai/"><h6>&gt;&nbsp;&nbsp; AI & Agentic Coding</h6></a></div>
+    <div class="article"><a href="/topik/elixir/"><h6>&gt;&nbsp;&nbsp; Elixir, OTP, dan cara berpikir fungsional</h6></a></div>
+    <div class="article"><a href="/topik/web/"><h6>&gt;&nbsp;&nbsp; Web Practical (frontend + performance + DX)</h6></a></div>
+    <div class="article"><a href="/topik/produktivitas/"><h6>&gt;&nbsp;&nbsp; Produktivitas untuk developer</h6></a></div>
+  </div>
+
+  <p style="font-size: 0.9rem; color: var(--meta-color);">
+    Atau lihat semua <a href="/tags">Topik</a> (tag list).
+  </p>
+
+  <a class="back" href="/">&lt; Kembali ke halaman utama</a>
+</main>

--- a/src/topik/produktivitas.njk
+++ b/src/topik/produktivitas.njk
@@ -1,0 +1,32 @@
+---
+title: "Produktivitas untuk Developer"
+layout: main
+permalink: "/topik/produktivitas/"
+---
+
+<main>
+  <h2>Produktivitas untuk Developer</h2>
+  <p style="color: var(--meta-color); margin-top: -0.5rem; font-size: 0.95rem;">
+    Kurasi tulisan yang biasanya aku share ke teman-teman: kebiasaan, mindset, dan sistem.
+  </p>
+
+  <h3 style="margin-top: 1.5rem;">Mulai dari sini</h3>
+  <div class="articles">
+    <div class="article"><a href="/2017/05/11/5-kebiasaan-coding/"><h6>&gt;&nbsp;&nbsp; 5 Kebiasaan Coding yang Menjadikan Kamu Super Developer</h6></a></div>
+    <div class="article"><a href="/2018/09/17/cara-belajar-pemrograman/"><h6>&gt;&nbsp;&nbsp; Cara Belajar Pemrograman yang Benar</h6></a></div>
+    <div class="article"><a href="/2021/09/12/tentang-friction-log/"><h6>&gt;&nbsp;&nbsp; Tentang Friction Log</h6></a></div>
+    <div class="article"><a href="/panduan-menulis/"><h6>&gt;&nbsp;&nbsp; Panduan Menulis Artikel Pemrograman</h6></a></div>
+  </div>
+
+  <h3 style="margin-top: 1.5rem;">Tools & catatan</h3>
+  <div class="articles">
+    <div class="article"><a href="/catatan/menemukan-kegunaan-obsidian/"><h6>&gt;&nbsp;&nbsp; Menemukan Kegunaan Obsidian</h6></a></div>
+    <div class="article"><a href="/catatan/digital-garden/"><h6>&gt;&nbsp;&nbsp; Digital Garden</h6></a></div>
+  </div>
+
+  <p style="font-size: 0.9rem; color: var(--meta-color);">
+    Lihat juga: <a href="/tags/produktivitas/">Topik: produktivitas</a> · <a href="/tags/belajar/">Topik: belajar</a> · <a href="/tags/menulis/">Topik: menulis</a>
+  </p>
+
+  <a class="back" href="/topik/">&lt; Semua topik pilihan</a>
+</main>

--- a/src/topik/web.njk
+++ b/src/topik/web.njk
@@ -1,0 +1,30 @@
+---
+title: "Web Practical"
+layout: main
+permalink: "/topik/web/"
+---
+
+<main>
+  <h2>Web Practical</h2>
+  <p style="color: var(--meta-color); margin-top: -0.5rem; font-size: 0.95rem;">
+    Kurasi catatan web yang praktis: dari konsep sampai implementasi.
+  </p>
+
+  <h3 style="margin-top: 1.5rem;">Mulai dari sini</h3>
+  <div class="articles">
+    <div class="article"><a href="/2020/02/03/ekosistemjs/"><h6>&gt;&nbsp;&nbsp; Ekosistem JavaScript</h6></a></div>
+    <div class="article"><a href="/web-scraping/"><h6>&gt;&nbsp;&nbsp; Web Scraping</h6></a></div>
+    <div class="article"><a href="/2018/08/20/machine-learning-for-web-developers/"><h6>&gt;&nbsp;&nbsp; Machine Learning for Web Developers</h6></a></div>
+  </div>
+
+  <h3 style="margin-top: 1.5rem;">Cerita & event</h3>
+  <div class="articles">
+    <div class="article"><a href="/2018/12/22/pengalaman-pertama-cds/"><h6>&gt;&nbsp;&nbsp; Menjadi GDE dan Pengalaman Pertama Menghadiri Chrome Dev Summit</h6></a></div>
+  </div>
+
+  <p style="font-size: 0.9rem; color: var(--meta-color);">
+    Lihat juga: <a href="/tags/web/">Topik: web</a> · <a href="/tags/javascript/">Topik: javascript</a> · <a href="/tags/frontend/">Topik: frontend</a>
+  </p>
+
+  <a class="back" href="/topik/">&lt; Semua topik pilihan</a>
+</main>


### PR DESCRIPTION
Menambah halaman kurasi untuk jalur social → blog:

- /topik/ (index) berisi 4 hub utama
- /topik/ai/ (AI & agentic)
- /topik/elixir/ (Elixir/OTP/FP)
- /topik/web/ (Web practical)
- /topik/produktivitas/ (Produktivitas)

Tujuan: ada landing page yang enak untuk dishare berulang dari X/LinkedIn (bio/pinned post), dan memudahkan pembaca baru memilih jalur bacaan.

Catatan:
- Sementara kurasi masih hardcoded (manual list) biar cepat rilis.
- Ada link baru "🧭 Mulai" di hero nav homepage menuju /topik/.
