### PR TITLE
ui: add spacing under header

### DIFF
--- a/assets/global.css
+++ b/assets/global.css
@@ -88,6 +88,16 @@ body {
     transition: background-color 0.3s ease, color 0.3s ease;
 }
 
+.site-header {
+    margin-bottom: 1.25rem;
+}
+
+@media (max-width: 600px) {
+    .site-header {
+        margin-bottom: 1rem;
+    }
+}
+
 a {
     color: var(--link-color);
     text-decoration: none;

--- a/src/_includes/main.njk
+++ b/src/_includes/main.njk
@@ -12,7 +12,7 @@ title: Judul
     {% include 'head.njk' %}
   </head>
   <body>
-    <div style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+    <header class="site-header" style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
       <div style="display:flex; align-items:center; gap: 0.75rem;">
         <h1 style="margin:0;"><a href="/">👋 Saya Riza!</a></h1>
         <nav class="hero-nav" style="margin-left: .25rem;">
@@ -22,7 +22,7 @@ title: Judul
         </nav>
       </div>
       <button id="theme-toggle" class="theme-toggle" aria-label="Toggle Dark Mode">🌙</button>
-    </div>
+    </header>
     {{ content | safe }}
     {% include 'theme-toggle.njk' %}
   </body>


### PR DESCRIPTION
Tambah breathing room di bagian atas halaman (header + pill nav) supaya judul halaman/topik nggak nempel.

- Wrap header di layout `main` dengan `<header class="site-header">`
- Tambah CSS `.site-header { margin-bottom: 1.25rem; }` (mobile: 1rem)

Ini harus bikin halaman /tags, /topik, dll terasa lebih lega.
