### PR TITLE
fix: remove horizontal scroll on article pages (mobile)

### DIFF
--- a/assets/tulisan.css
+++ b/assets/tulisan.css
@@ -31,6 +31,10 @@ table {
 
 table {
     border-collapse: collapse;
+    width: 100%;
+    display: block;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
 }
 
 th,
@@ -48,6 +52,14 @@ pre.shiki {
     font-size: 1rem;
     text-wrap: balance;
     line-height: 1.5rem;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
+/* Generic pre blocks (non-shiki) */
+pre {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
 }
 
 p > code {


### PR DESCRIPTION
Di mobile, halaman tulisan kadang muncul horizontal scroll (contoh: /catatan/asisten-ngoding-4/) karena ada elemen yang overflow (table dan code blocks).

Perubahan:
- `assets/tulisan.css`: buat `table` jadi scrollable secara horizontal (display:block + overflow-x:auto)
- Tambah `overflow-x:auto` untuk `pre` dan `pre.shiki`

Harusnya ini menghilangkan scroll horizontal tanpa mengubah layout di desktop.
