### PR TITLE
feat: Auto-generate Table of Contents for articles

### DIFF
--- a/assets/tulisan.css
+++ b/assets/tulisan.css
@@ -398,6 +398,72 @@ small {
     }
 }
 
+/* Table of Contents */
+.toc {
+    margin: 1.5rem 0;
+    padding: 1rem 1.25rem;
+    background: var(--nav-btn-bg);
+    border-radius: 0.5rem;
+    border-left: 3px solid var(--button-bg);
+}
+
+.toc summary {
+    font-weight: bold;
+    font-size: 1.1rem;
+    cursor: pointer;
+    list-style: none;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.toc summary::-webkit-details-marker {
+    display: none;
+}
+
+.toc summary::after {
+    content: "▼";
+    font-size: 0.7rem;
+    transition: transform 0.2s;
+    margin-left: auto;
+}
+
+.toc details:not([open]) summary::after {
+    transform: rotate(-90deg);
+}
+
+.toc ol {
+    margin: 0.75rem 0 0 0;
+    padding-left: 1.25rem;
+}
+
+.toc ol ol {
+    margin-top: 0.25rem;
+}
+
+.toc li {
+    margin: 0.35rem 0;
+    font-size: 0.95rem;
+    line-height: 1.4;
+}
+
+.toc a {
+    color: var(--text-color);
+    border-bottom: none;
+    opacity: 0.85;
+}
+
+.toc a:hover {
+    opacity: 1;
+    border-bottom: 1px solid var(--text-color);
+}
+
+@media print {
+    .toc {
+        display: none !important;
+    }
+}
+
 /* Share links (unobtrusive) */
 .share-links {
     display: inline-flex;

--- a/src/_includes/tulisan.njk
+++ b/src/_includes/tulisan.njk
@@ -45,7 +45,6 @@ title: Judul
     <div class="reading-progress" id="reading-progress"></div>
     <a href="#main-content" class="skip-link">Langsung ke konten utama</a>
     <nav class="container" style="display: flex; justify-content: space-between; align-items: center;">
-      {%- if '/catatan/' in page.url %}
       <ol class="breadcrumb" aria-label="Breadcrumb" itemscope itemtype="https://schema.org/BreadcrumbList">
         <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
           <a itemprop="item" href="/"><span itemprop="name">Beranda</span></a>
@@ -60,7 +59,6 @@ title: Judul
           <meta itemprop="position" content="3" />
         </li>
       </ol>
-      {%- endif %}
       <button id="theme-toggle" class="theme-toggle" aria-label="Toggle Dark Mode" style="background:none; border:none; cursor:pointer; font-size:1.5rem;">🌙</button>
     </nav>
 
@@ -132,7 +130,7 @@ title: Judul
         </p>
       </section>
 
-      {%- if '/catatan/' in page.url %}
+      {%- if tags and 'catatan' in tags %}
       <section class="related-articles">
         <h3>📚 Artikel Terkait</h3>
         <div class="related-grid">
@@ -149,7 +147,7 @@ title: Judul
       <hr />
 
       {%- set show_comments = false %}
-      {%- if '/catatan/' in page.url %}{% set show_comments = true %}{%- endif %}
+      {%- if tags and 'catatan' in tags %}{% set show_comments = true %}{%- endif %}
       {%- if page.url == '/now/' %}{% set show_comments = true %}{%- endif %}
       {%- if page.url == '/uses/' %}{% set show_comments = true %}{%- endif %}
 

--- a/src/catatan/ekosistemjs.md
+++ b/src/catatan/ekosistemjs.md
@@ -15,8 +15,6 @@ tags:
 
 ---
 
-# Ekosistem JavaScript di Indonesia
-
 This article also available in [ Engilish ](/ekosistemjs/en/).
 
 Artikel ini akan membahas tentang bagaimana perkembangan ekosistem JavaScript di
@@ -24,32 +22,9 @@ Indonesia. Namun sebelum kita masuk ke pembahasan utama, mari kita bahas dulu
 tentang definisi ekosistem di konteks artikel ini. Topik ini merupakan materi
 yang saya bawakan ketika mengisi keynote di [ JSDay 2019 ](https://jsday.id).
 
-## Daftar Isi
-
-- [Tentang Ekosistem JavaScript](#tentang-ekosistem-javascript)
-- [Sudut Pandang Pembahasan](#sudut-pandang-pembahasan)
-  - [Sudut Pandang Pemula](#sudut-pandang-pemula)
-    - [Mulai Dari Mana?](#mulai-dari-mana)
-    - [Belajar Framework Apa?](#belajar-framework-apa)
-    - [Literatur atau Buku Tersedia](#literatur-atau-buku-tersedia)
-    - [Kursus Video Online](#kursus-video-online)
-  - [Sudut Pandang Profesional](#sudut-pandang-profesional)
-    - [Contoh Aplikasi](#contoh-aplikasi)
-    - [Tutorial Berbahasa Indonesia](#tutorial-berbahasa-indonesia)
-    - [Alat Bantu dan Boilerplate](#alat-bantu-dan-boilerplate)
-    - [Mulai Menggunakan](#mulai-menggunakan)
-    - [Dukungan Komunitas](#dukungan-komunitas)
-    - [Pustaka Pendukung](#pustaka-pendukung)
-    - [Performa](#performa)
-    - [Lowongan Pekerjaan](#lowongan-pekerjaan)
-  - [Sudut Pandang Master](#sudut-pandang-master)
-    - [Talenta Tersedia](#talenta-tersedia)
-    - [Tingkat Maturity](#tingkat-maturity)
-- [Kesimpulan](#kesimpulan)
-
 <blockquote class="twitter-tweet" data-theme="dark"><p lang="en" dir="ltr">Riza is delivering keynote at <a href="https://twitter.com/hashtag/jsdayid?src=hash&amp;ref_src=twsrc%5Etfw">#jsdayid</a>. First JavaScript conference in Indonesia. <a href="https://twitter.com/rizafahmi22?ref_src=twsrc%5Etfw">@rizafahmi22</a> <a href="https://t.co/yxXKm1cNxM">pic.twitter.com/yxXKm1cNxM</a></p>&mdash; Jecelyn Yeen (@JecelynYeen) <a href="https://twitter.com/JecelynYeen/status/1177778326758277120?ref_src=twsrc%5Etfw">September 28, 2019</a></blockquote>
 
-# Tentang Ekosistem JavaScript
+## Tentang Ekosistem JavaScript
 
 > “An ecosystem is a community of living organisms and their interactions with their abiotic (non-living) environment.” — Ecology of ecosystems
 
@@ -60,7 +35,7 @@ Yang dimaksud ekosistem disini diantaranya adalah komunitas, grup dan diskusi se
 - Dukungan komunitas di sekitar alat bantu dan juga lingkungan sekitar
 - Pembahasan akan fokus di frontend karena JavaScript di sisi backend cukup _straightforward_.
 
-# Sudut Pandang Pembahasan
+## Sudut Pandang Pembahasan
 
 Artikel ini akan membagi pembahasan kepada tiga sudut pandang. Sudut pandang pertama ditujukan untuk yang baru mulai belajar, kita sebut saja pemula. Kita akan mencoba menjawab beberapa pertanyaan yang sering muncul di benak pemula ketika ingin belajar JavaScript. Kemudian kita juga akan membahas JavaScript dari sudut pandang teman-teman yang sudah pernah membuat aplikasi dan ingin belajar hal baru terutama teknologi web. Kita sebut saja sebagai profesional. Sudut pandang terakhir diperuntukkan kepada para pengambil keputusan seperti Vice President, Chief Technology Officer, Team Lead dan lain sebagainya. Kita menyebutnya sebagai sudut pandang master.
 
@@ -592,7 +567,7 @@ Angular memiliki baris kode yang paling banyak dengan jumlah test case juga yang
 
 Maksud saya menampilkan data ini bukan untuk adu siapa yang paling banyak jumlah test, tapi lebih melihat gambaran _framework_ mana yang peduli dengan testing. Dan data ini bisa jadi bereleasi dengan seberapa mudah aplikasi kita di test nantinya.
 
-# Kesimpulan
+## Kesimpulan
 
 Masa-masa saat ini adalah masa yang sangat menyenangkan dan _exciting_ terutama untuk developer JavaScript. Ekosistem pendukung semakin matang, pilihan untuk belajar sangat banyak, begitu juga media dan pilihan cara belajar. Bisa belajar dari artikel, buku hingga format video. Ada pustaka atau framework yang sangat _developer friendly_, dengan beberapa langkah kita sudah bisa membuat aplikasi. Ada juga yang sangat _user friendly_ dalam artian mungkin untuk _development_ butuh waktu yang agak panjang dan tidak semudah yang lain, namun hasil akhirnya sangat memanjakan. Aplikasinya cepat dan ringan tidak memberatkan pengguna.
 

--- a/src/catatan/ekosistemjs/en.md
+++ b/src/catatan/ekosistemjs/en.md
@@ -17,29 +17,6 @@ Translated by [Ajeng Sugiarti](mailto:ajeng.sugiarti@gmail.com).
 
 This article is going to discuss JavaScript ecosystem growth in Indonesia. Before going deep into the main topic though, let’s first talk about what this article refers to as an ecosystem. This topic is the one I delivered as a keynote session in JSDay 2019.
 
-## Table of Content
-
-- [About JavaScript Ecosystem](#about-javascript-ecosystem)
-- [Discussion Point of View](#discussion-point-of-view)
-  - [Beginners Point of View](#beginners-point-of-view)
-    - [Where Do We Start?](#where-do-we-start)
-    - [Which Framework?](#which-framework)
-    - [Books or Literature Availability](#books-or-literature-availability)
-    - [Online Courses](#online-courses)
-  - [Professionals Point of View](#professionals-point-of-view)
-    - [Sample Applications](#sample-applications)
-    - [Tutorials in Bahasa Indonesia](#tutorials-in-bahasa-indonesia)
-    - [Tools and Boilerplates](#tools-and-boilerplates)
-    - [How to Use](#how-to-use)
-    - [Community Support](#community-support)
-    - [Supporting Libraries](#supporting-libraries)
-    - [Performance](#performance)
-    - [Job Vacancies](#job-vacancies)
-  - [Masters Point of View](#masters-point-of-view)
-    - [Available Talents](#available-talents)
-    - [Maturity Level](#maturity-level)
-- [Conclusion](#conclusion)
-
 ## About JavaScript Ecosystem
 
 > “An ecosystem is a community of living organisms and their interactions with their abiotic (non-living) environment.” — Ecology of ecosystems


### PR DESCRIPTION
## Summary

Auto-generate a collapsible Table of Contents (Daftar Isi) for article pages with 3+ headings.

## Changes

- **TOC transform** in `eleventy.config.js` — extracts H2/H3 headings from article content, generates anchor IDs, and injects a nested ordered list
- **Seri (series) navigation** is placed above the TOC when present
- **Styles** in `tulisan.css` — theme-aware, collapsible `<details>` element, hidden in print
- **Breadcrumb/related articles/comments** — changed from URL path check (`/catatan/`) to tag-based check so articles with custom `permalink` also get breadcrumbs, related articles, and comments
- **ekosistemjs.md & en.md** — removed manual TOC, fixed H1→H2 heading levels

## Details

- TOC only appears on pages using the `tulisan` layout with 3+ H2/H3 headings
- Headings automatically get `id` attributes for anchor linking
- 14 out of 23 articles currently qualify for a TOC