### PR TITLE
fix: limit search results to articles only

### DIFF
--- a/src/_includes/tulisan.njk
+++ b/src/_includes/tulisan.njk
@@ -63,7 +63,7 @@ title: Judul
     </nav>
 
     <main class="container" id="main-content">
-      <article>
+      <article data-pagefind-body>
       {%- set canonicalUrl = "https://rizafahmi.com" + page.url -%}
       {%- set xShareHref = "https://twitter.com/intent/tweet?text=" + (title | urlencode) + "&url=" + (canonicalUrl | urlencode) -%}
       {%- set liShareHref = "https://www.linkedin.com/shareArticle?mini=true&url=" + (canonicalUrl | urlencode) + "&title=" + (title | urlencode) + "&summary=" + ((description or title) | urlencode) -%}


### PR DESCRIPTION
## Problem

Search page returns results from all pages (index, tags, ratecard, etc.) instead of just articles.

## Solution

Add `data-pagefind-body` attribute to the `<article>` element in `tulisan.njk`. This switches Pagefind to opt-in mode, so only article pages (51 pages) are indexed instead of all 102 HTML pages.