### PR TITLE
feat: activate Web Vitals tracking with GoatCounter

### DIFF
--- a/src/_includes/main.njk
+++ b/src/_includes/main.njk
@@ -25,6 +25,8 @@ title: Judul
       <button id="theme-toggle" class="theme-toggle" aria-label="Toggle Dark Mode">🌙</button>
     </header>
     {{ content | safe }}
+    {% include 'analytics.njk' %}
+    {% include 'webvitals.njk' %}
     {% include 'theme-toggle.njk' %}
   </body>
 </html>

--- a/src/_includes/serial.njk
+++ b/src/_includes/serial.njk
@@ -63,6 +63,7 @@ title: Judul
       });
     </script>
     {% include 'analytics.njk' %}
+    {% include 'webvitals.njk' %}
     {% include 'theme-toggle.njk' %}
   </body>
 </html>

--- a/src/_includes/tulisan.njk
+++ b/src/_includes/tulisan.njk
@@ -258,6 +258,7 @@ title: Judul
       });
     </script>
     {% include 'analytics.njk' %}
+    {% include 'webvitals.njk' %}
     {% include 'theme-toggle.njk' %}
   </body>
 </html>

--- a/src/_includes/webvitals.njk
+++ b/src/_includes/webvitals.njk
@@ -1,0 +1,18 @@
+<script type="module">
+  import {onCLS, onINP, onLCP, onFCP, onTTFB} from 'https://unpkg.com/web-vitals@4/dist/web-vitals.attribution.js?module';
+
+  function sendToGoatCounter(metric) {
+    if (typeof window.goatcounter === 'undefined' || !window.goatcounter.count) return;
+    window.goatcounter.count({
+      path: `web-vitals/${metric.name}`,
+      title: `${metric.name}: ${Math.round(metric.value)}`,
+      event: true
+    });
+  }
+
+  onCLS(sendToGoatCounter);
+  onINP(sendToGoatCounter);
+  onLCP(sendToGoatCounter);
+  onFCP(sendToGoatCounter);
+  onTTFB(sendToGoatCounter);
+</script>


### PR DESCRIPTION
## Summary
Activate Web Vitals performance monitoring using the `web-vitals` v4 library, sending metrics to GoatCounter as custom events.

## Changes
- Created `src/_includes/webvitals.njk` — captures CLS, INP, LCP, FCP, and TTFB
- Sends each metric as a GoatCounter event under `web-vitals/{metric-name}`
- Integrated into all three layouts: `main.njk`, `tulisan.njk`, `serial.njk`

## How to verify
Check GoatCounter dashboard for events under the `web-vitals/` path prefix after deployment.

Closes #123