### PR TITLE
feat(shiki): configure monokai theme for code syntax highlighting

### DIFF
--- a/assets/tulisan.css
+++ b/assets/tulisan.css
@@ -233,6 +233,18 @@ pre.shiki .line.highlighted {
     background-color: rgba(26, 59, 245, 0.25);
 }
 
+[data-theme="dark"] pre.shiki {
+    background-color: var(--shiki-dark-bg) !important;
+    color: var(--shiki-dark) !important;
+}
+
+[data-theme="dark"] pre.shiki span {
+    color: var(--shiki-dark) !important;
+    font-style: var(--shiki-dark-font-style) !important;
+    font-weight: var(--shiki-dark-font-weight) !important;
+    text-decoration: var(--shiki-dark-text-decoration) !important;
+}
+
 .code-block {
     position: relative;
 }

--- a/src/libs/shiki.js
+++ b/src/libs/shiki.js
@@ -5,7 +5,7 @@ export default function(eleventyConfig, options) {
     const shiki = await import("shiki");
 
     const highlighter = await shiki.createHighlighter({
-      themes: ["light-plus", "dark-plus"],
+      themes: ["monokai"],
       langs: [
         "shell",
         "html",
@@ -112,7 +112,10 @@ export default function(eleventyConfig, options) {
 
           const html = highlighter.codeToHtml(code, {
             lang: lang,
-            theme: "dark-plus",
+            themes: {
+              light: "monokai",
+              dark: "monokai",
+            },
             meta: { __raw: meta },
             transformers,
           });


### PR DESCRIPTION
Update Shiki syntax highlighter config to use the classic Monokai theme across both light and dark site modes. Add CSS rules in assets/tulisan.css to support the dark mode toggle by overriding colors using Shiki's dual-theme CSS variables.