### PR TITLE
feat(karya): data-driven Open Source cards with optional access URLs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,12 @@ See `DESIGN.md` for the full design spec. Key rules:
 - Series articles use `series` and `series_index` frontmatter
 - Custom `image` or `cover` frontmatter disables auto-generated OG images for that article
 
+## Curated Data
+
+- The "Open Source" cards on `/showcase` (Karya) are rendered from `src/_data/karya.js`,
+  a hand-curated list with an Indonesian header comment explaining how to edit it.
+  The "Lainnya" section on that page is still hand-written HTML in `src/showcase.njk`.
+
 ## Deployment
 
 - Hosted on **Netlify** with auto-deploy on merge to `main`
@@ -128,3 +134,10 @@ See `DESIGN.md` for the full design spec. Key rules:
 | `GOATCOUNTER_CACHE_TTL_HOURS` | No       | Cache TTL for views (default: 12)     |
 
 The site builds fine without these — view counts are simply hidden.
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,11 +28,11 @@ npm test         # run unit tests
 | `npm run build:prod`   | Alias for `npm run build` (Netlify compat)                             |
 | `npm run debug`        | Dev server with `DEBUG=*` output                                       |
 | `npm test`             | Run unit tests via `node --test test/*.test.js`                        |
-| `npm run lint`         | Run ESLint on all source files                                         |
-| `npm run lint:fix`     | Auto-fix ESLint issues                                                 |
-| `npm run format`       | Check formatting with Prettier                                         |
-| `npm run format:fix`   | Auto-format all files with Prettier                                    |
-| `npm run check`        | Run lint + format + test (full CI verification)                        |
+| `npm run lint`         | Run Biome linter on source files                                       |
+| `npm run lint:fix`     | Auto-fix Biome lint issues                                              |
+| `npm run format`       | Check formatting with Biome                                            |
+| `npm run format:fix`   | Auto-format files with Biome                                           |
+| `npm run check`        | Run `biome check` + unit tests (full CI verification)                  |
 | `npm run new:catatan`  | Scaffold a new article under `src/catatan/`                            |
 
 ## Tech Stack

--- a/assets/global.css
+++ b/assets/global.css
@@ -433,9 +433,26 @@ blockquote {
   transform: translateY(-2px);
 }
 
+/* Second link on a card: where the project can actually be used, as opposed to
+   the card title, which points at the source on GitHub. */
+.card-links {
+  margin: 0.75rem 0 0 !important;
+}
+
+.card-link {
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  font-weight: bold;
+  color: var(--link-color);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-bottom: 2px solid currentColor;
+}
+
 .card:hover h3,
 .card:hover h3 a,
 .card:hover p,
+.card:hover .card-link,
 .card:hover .badge {
   color: #ffffff !important;
 }

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -2,6 +2,7 @@ import fs, { existsSync } from "node:fs";
 import path from "node:path";
 import Image from "@11ty/eleventy-img";
 import pluginRss from "@11ty/eleventy-plugin-rss";
+import { selectProjects } from "./src/libs/karya.js";
 import { generateOgImage } from "./src/libs/og-image.js";
 import { getRelatedPosts } from "./src/libs/related.js";
 import shikiPlugin from "./src/libs/shiki.js";
@@ -131,6 +132,10 @@ export default function (eleventyConfig) {
     if (Number.isNaN(d.getTime())) return "";
     return d.toISOString();
   });
+
+  // "Open Source" cards on /showcase come from the hand-curated src/_data/karya.js;
+  // this only cleans the entries up, it never reorders them.
+  eleventyConfig.addFilter("karyaProjects", (projects) => selectProjects(projects));
 
   eleventyConfig.addFilter("jsonify", (value) => {
     return JSON.stringify(value ?? "");

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@fontsource/unbounded": "^5.2.8",
         "@shikijs/transformers": "^3.22.0",
         "husky": "^9.1.7",
+        "nunjucks": "3.2.4",
         "pagefind": "^1.4.0",
         "rimraf": "5.0.5",
         "sharp": "^0.34.5",
@@ -3205,6 +3206,7 @@
       "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.4.tgz",
       "integrity": "sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "a-sync-waterfall": "^1.0.0",
         "asap": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@fontsource/unbounded": "^5.2.8",
     "@shikijs/transformers": "^3.22.0",
     "husky": "^9.1.7",
+    "nunjucks": "3.2.4",
     "pagefind": "^1.4.0",
     "rimraf": "5.0.5",
     "sharp": "^0.34.5",

--- a/src/_data/karya.js
+++ b/src/_data/karya.js
@@ -36,35 +36,38 @@ export default [
     name: "slopcase",
     description: "Showcase untuk proyek AI-generated: submit & voting, “slop atau bukan?”",
     repo: "https://github.com/rizafahmi/slopcase",
-    // TODO(riza): isi `url` kalau slopcase sudah bisa diakses online.
     tags: ["Elixir", "Phoenix LiveView", "SQLite"],
   },
   {
     name: "mbb",
     description: "CLI assistant sederhana untuk prompt tools & agentic loop di terminal.",
     repo: "https://github.com/rizafahmi/mbb",
-    // TODO(riza): isi `url` kalau mbb punya halaman/dokumentasi yang bisa dibuka.
     tags: ["Elixir", "CLI", "Anthropic"],
   },
   {
     name: "gemini-for-web-dev",
     description: "Contoh app Gemini API untuk kebutuhan web developer (#geminisprint).",
     repo: "https://github.com/rizafahmi/gemini-for-web-dev",
-    // TODO(riza): isi `url` kalau demo app-nya sudah di-deploy.
     tags: ["Node.js", "Gemini API", "Turso"],
   },
   {
     name: "workspresso",
     description: "Cari coffee shop yang work-friendly, dengan data Wi‑Fi, colokan, noise, dll.",
     repo: "https://github.com/rizafahmi/workspresso",
-    // TODO(riza): isi `url` kalau workspresso sudah online.
     tags: ["Astro", "Node.js", "SQLite"],
   },
   {
     name: "ai-workshop-material",
     description: "Materi workshop AI (DevFest GDG Jogja 2025): skenario AI di luar chatbot.",
     repo: "https://github.com/rizafahmi/ai-workshop-material",
-    // TODO(riza): isi `url` kalau materinya dipublikasikan di web.
+    url: "https://workshop.rizafahmi.com",
     tags: ["Workshop", "JavaScript", "LLM"],
+  },
+  {
+    name: "makan-dimana",
+    description: "Voting bareng buat nentuin “mau makan di mana?”, dibangun local-first.",
+    repo: "https://github.com/rizafahmi/makan-dimana",
+    url: "https://vote.rizafahmi.com",
+    tags: ["Astro", "TypeScript", "Local-first"],
   },
 ];

--- a/src/_data/karya.js
+++ b/src/_data/karya.js
@@ -1,0 +1,70 @@
+/**
+ * DAFTAR OPEN SOURCE — isi bagian "Open Source" di halaman /showcase (Karya)
+ * ==========================================================================
+ *
+ * File ini murni daftar, tidak ada logika apa pun. Cukup edit isinya lalu
+ * jalankan `npm run build` (atau `npm start`), halaman Karya langsung ikut.
+ *
+ * CARA MENAMBAH PROYEK
+ *   Salin satu blok `{ ... }` di bawah, tempel di posisi yang diinginkan,
+ *   lalu ganti isinya. Jangan lupa koma di akhir blok.
+ *
+ * CARA MENGHAPUS PROYEK
+ *   Hapus seluruh blok `{ ... }` milik proyek itu.
+ *
+ * CARA MENGATUR URUTAN
+ *   Urutan kartu di halaman = urutan tulis di file ini, dari atas ke bawah.
+ *   Pindahkan blok ke atas kalau ingin proyeknya tampil lebih dulu.
+ *
+ * ISI SATU BLOK
+ *   name        (wajib) Nama proyek. Tampil sebagai judul kartu, sekaligus
+ *               tautan ke repo GitHub-nya.
+ *   description (wajib) Satu kalimat bahasa Indonesia. Ringkas saja.
+ *   repo        (wajib) Tautan lengkap ke repo GitHub, diawali https://
+ *   url         (opsional) Tautan tempat proyeknya bisa langsung dipakai atau
+ *               dicoba — misal https://workspresso.app. Tampil sebagai tautan
+ *               kedua di kartu, terpisah dari tautan kode. Kalau proyeknya
+ *               memang tidak punya (CLI, materi workshop, dsb.), hapus saja
+ *               barisnya — tidak akan ada tautan kosong di halaman.
+ *   tags        (opsional) Daftar teknologi, contoh: ["Elixir", "SQLite"]
+ *
+ * Bagian "Lainnya" di halaman Karya tidak diatur dari sini; itu masih ditulis
+ * tangan langsung di src/showcase.njk.
+ */
+export default [
+  {
+    name: "slopcase",
+    description: "Showcase untuk proyek AI-generated: submit & voting, “slop atau bukan?”",
+    repo: "https://github.com/rizafahmi/slopcase",
+    // TODO(riza): isi `url` kalau slopcase sudah bisa diakses online.
+    tags: ["Elixir", "Phoenix LiveView", "SQLite"],
+  },
+  {
+    name: "mbb",
+    description: "CLI assistant sederhana untuk prompt tools & agentic loop di terminal.",
+    repo: "https://github.com/rizafahmi/mbb",
+    // TODO(riza): isi `url` kalau mbb punya halaman/dokumentasi yang bisa dibuka.
+    tags: ["Elixir", "CLI", "Anthropic"],
+  },
+  {
+    name: "gemini-for-web-dev",
+    description: "Contoh app Gemini API untuk kebutuhan web developer (#geminisprint).",
+    repo: "https://github.com/rizafahmi/gemini-for-web-dev",
+    // TODO(riza): isi `url` kalau demo app-nya sudah di-deploy.
+    tags: ["Node.js", "Gemini API", "Turso"],
+  },
+  {
+    name: "workspresso",
+    description: "Cari coffee shop yang work-friendly, dengan data Wi‑Fi, colokan, noise, dll.",
+    repo: "https://github.com/rizafahmi/workspresso",
+    // TODO(riza): isi `url` kalau workspresso sudah online.
+    tags: ["Astro", "Node.js", "SQLite"],
+  },
+  {
+    name: "ai-workshop-material",
+    description: "Materi workshop AI (DevFest GDG Jogja 2025): skenario AI di luar chatbot.",
+    repo: "https://github.com/rizafahmi/ai-workshop-material",
+    // TODO(riza): isi `url` kalau materinya dipublikasikan di web.
+    tags: ["Workshop", "JavaScript", "LLM"],
+  },
+];

--- a/src/_includes/karya_open_source.njk
+++ b/src/_includes/karya_open_source.njk
@@ -1,0 +1,28 @@
+{# Kartu bagian "Open Source" di /showcase.
+   Isinya diatur dari src/_data/karya.js — jangan tulis proyek langsung di sini. #}
+{% macro openSourceCards(projects) %}
+  <div class="card-grid">
+    {%- for project in projects %}
+    <div class="card">
+      {%- if project.repo %}
+      <h3><a href="{{ project.repo }}" target="_blank" rel="noopener noreferrer">{{ project.name }}</a></h3>
+      {%- else %}
+      <h3>{{ project.name }}</h3>
+      {%- endif %}
+      {%- if project.description %}
+      <p>{{ project.description }}</p>
+      {%- endif %}
+      {%- if project.url %}
+      <p class="card-links"><a class="card-link" href="{{ project.url }}" target="_blank" rel="noopener noreferrer">Coba langsung &rarr;</a></p>
+      {%- endif %}
+      {%- if project.tags.length %}
+      <div class="badges" aria-label="Tech stack">
+        {%- for tag in project.tags %}
+        <span class="badge">{{ tag }}</span>
+        {%- endfor %}
+      </div>
+      {%- endif %}
+    </div>
+    {%- endfor %}
+  </div>
+{% endmacro %}

--- a/src/libs/karya.js
+++ b/src/libs/karya.js
@@ -1,0 +1,34 @@
+/**
+ * Helpers behind the "Open Source" section of /showcase (Karya).
+ *
+ * The content itself is hand-curated in src/_data/karya.js — this module only
+ * cleans the entries up. No fetching and no inferring: whatever the data file
+ * says, in the order it says.
+ */
+
+function cleanText(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function cleanUrl(value) {
+  const text = cleanText(value);
+  if (!text) return null;
+  return /^https?:\/\//i.test(text) ? text : null;
+}
+
+export function normalizeProject(raw) {
+  return {
+    name: cleanText(raw?.name) ?? "",
+    description: cleanText(raw?.description),
+    repo: cleanUrl(raw?.repo),
+    url: cleanUrl(raw?.url),
+    tags: (Array.isArray(raw?.tags) ? raw.tags : []).map(cleanText).filter(Boolean),
+  };
+}
+
+export function selectProjects(rawProjects) {
+  if (!Array.isArray(rawProjects)) return [];
+  return rawProjects.map(normalizeProject).filter((project) => project.name.length > 0);
+}

--- a/src/showcase.njk
+++ b/src/showcase.njk
@@ -5,6 +5,9 @@ layout: main
 eleventyExcludeFromCollections: true
 ---
 
+{% import "karya_open_source.njk" as karyaCards %}
+{% set openSourceProjects = karya | karyaProjects %}
+
 <main id="main-content">
   <h2>Karya</h2>
   <p style="font-size: 1rem; margin: 0.5rem;">
@@ -12,57 +15,7 @@ eleventyExcludeFromCollections: true
   </p>
 
   <h3 style="margin: 1.5rem 0.5rem 0;">Open Source</h3>
-  <div class="card-grid">
-    <div class="card">
-      <h3><a href="https://github.com/rizafahmi/slopcase" target="_blank" rel="noopener noreferrer">slopcase</a></h3>
-      <p>Showcase untuk proyek AI-generated: submit & voting, “slop atau bukan?”</p>
-      <div class="badges" aria-label="Tech stack">
-        <span class="badge">Elixir</span>
-        <span class="badge">Phoenix LiveView</span>
-        <span class="badge">SQLite</span>
-      </div>
-    </div>
-
-    <div class="card">
-      <h3><a href="https://github.com/rizafahmi/mbb" target="_blank" rel="noopener noreferrer">mbb</a></h3>
-      <p>CLI assistant sederhana untuk prompt tools & agentic loop di terminal.</p>
-      <div class="badges" aria-label="Tech stack">
-        <span class="badge">Elixir</span>
-        <span class="badge">CLI</span>
-        <span class="badge">Anthropic</span>
-      </div>
-    </div>
-
-    <div class="card">
-      <h3><a href="https://github.com/rizafahmi/gemini-for-web-dev" target="_blank" rel="noopener noreferrer">gemini-for-web-dev</a></h3>
-      <p>Contoh app Gemini API untuk kebutuhan web developer (#geminisprint).</p>
-      <div class="badges" aria-label="Tech stack">
-        <span class="badge">Node.js</span>
-        <span class="badge">Gemini API</span>
-        <span class="badge">Turso</span>
-      </div>
-    </div>
-
-    <div class="card">
-      <h3><a href="https://github.com/rizafahmi/workspresso" target="_blank" rel="noopener noreferrer">workspresso</a></h3>
-      <p>Cari coffee shop yang work-friendly, dengan data Wi‑Fi, colokan, noise, dll.</p>
-      <div class="badges" aria-label="Tech stack">
-        <span class="badge">Astro</span>
-        <span class="badge">Node.js</span>
-        <span class="badge">SQLite</span>
-      </div>
-    </div>
-
-    <div class="card">
-      <h3><a href="https://github.com/rizafahmi/ai-workshop-material" target="_blank" rel="noopener noreferrer">ai-workshop-material</a></h3>
-      <p>Materi workshop AI (DevFest GDG Jogja 2025): skenario AI di luar chatbot.</p>
-      <div class="badges" aria-label="Tech stack">
-        <span class="badge">Workshop</span>
-        <span class="badge">JavaScript</span>
-        <span class="badge">LLM</span>
-      </div>
-    </div>
-  </div>
+  {{ karyaCards.openSourceCards(openSourceProjects) }}
 
   <hr style="margin: 2rem 0.5rem;" />
 

--- a/test/karya-page.test.js
+++ b/test/karya-page.test.js
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import nunjucks from "nunjucks";
+
+import { selectProjects } from "../src/libs/karya.js";
+
+const env = new nunjucks.Environment(new nunjucks.FileSystemLoader("src/_includes"), {
+  autoescape: true,
+});
+
+function render(rawProjects) {
+  return env.renderString(
+    '{% import "karya_open_source.njk" as karya %}{{ karya.openSourceCards(projects) }}',
+    { projects: selectProjects(rawProjects) },
+  );
+}
+
+const BASE = {
+  name: "workspresso",
+  description: "Cari coffee shop yang work-friendly.",
+  repo: "https://github.com/rizafahmi/workspresso",
+};
+
+test("renders a card with the project name linked to its GitHub repo", () => {
+  const html = render([BASE]);
+
+  assert.match(html, /class="card-grid"/);
+  assert.match(html, /class="card"/);
+  assert.match(
+    html,
+    /<h3><a href="https:\/\/github\.com\/rizafahmi\/workspresso"[^>]*>workspresso<\/a><\/h3>/,
+  );
+  assert.match(html, /Cari coffee shop yang work-friendly\./);
+});
+
+test("renders tech tags as badges, in order", () => {
+  const html = render([{ ...BASE, tags: ["Astro", "Node.js", "SQLite"] }]);
+
+  assert.match(html, /<div class="badges" aria-label="Tech stack">/);
+  assert.match(html, /<span class="badge">Astro<\/span>/);
+  assert.ok(html.indexOf("Astro") < html.indexOf("SQLite"));
+});
+
+test("renders a second, separately labelled link when the project has an access url", () => {
+  const html = render([{ ...BASE, url: "https://workspresso.app" }]);
+
+  assert.match(html, /href="https:\/\/workspresso\.app"/);
+  assert.match(html, /class="card-link"/);
+  // The two links must read differently: repo is the title, the access url is labelled.
+  assert.match(html, /Coba/);
+});
+
+test("renders only the GitHub link when the project has no access url", () => {
+  const html = render([BASE]);
+
+  assert.doesNotMatch(html, /card-link/);
+  assert.doesNotMatch(html, /card-links/);
+  assert.equal(html.match(/<a /g).length, 1);
+});
+
+test("a project with no tags renders no badges container", () => {
+  const html = render([BASE]);
+
+  assert.doesNotMatch(html, /badges/);
+});
+
+test("an empty list renders an empty grid, not broken markup", () => {
+  const html = render([]);
+
+  assert.match(html, /class="card-grid"/);
+  assert.doesNotMatch(html, /class="card"/);
+});
+
+test("cards render in the order the data file lists them", () => {
+  const html = render([
+    { ...BASE, name: "satu" },
+    { ...BASE, name: "dua" },
+  ]);
+
+  assert.ok(html.indexOf("satu") < html.indexOf("dua"));
+});
+
+test("escapes text so a stray character in the data file cannot break the page", () => {
+  const html = render([{ ...BASE, description: "<script>alert(1)</script>" }]);
+
+  assert.doesNotMatch(html, /<script>/);
+  assert.match(html, /&lt;script&gt;/);
+});
+
+test("never renders undefined or null leaking from a missing optional field", () => {
+  const html = render([{ name: "solo", description: "Ada.", repo: "https://github.com/x/s" }]);
+
+  assert.doesNotMatch(html, /undefined|\bnull\b/);
+});

--- a/test/karya.test.js
+++ b/test/karya.test.js
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import karya from "../src/_data/karya.js";
+import { normalizeProject, selectProjects } from "../src/libs/karya.js";
+
+test("normalizeProject trims text and keeps the fields the card renders", () => {
+  const project = normalizeProject({
+    name: "  mbb  ",
+    description: "  CLI assistant sederhana.  ",
+    repo: " https://github.com/rizafahmi/mbb ",
+    url: " https://mbb.dev ",
+    tags: [" Elixir ", "CLI"],
+  });
+
+  assert.deepEqual(project, {
+    name: "mbb",
+    description: "CLI assistant sederhana.",
+    repo: "https://github.com/rizafahmi/mbb",
+    url: "https://mbb.dev",
+    tags: ["Elixir", "CLI"],
+  });
+});
+
+test("normalizeProject leaves the optional access url empty when there is none", () => {
+  assert.equal(normalizeProject({ name: "x" }).url, null);
+  assert.equal(normalizeProject({ name: "x", url: "" }).url, null);
+  assert.equal(normalizeProject({ name: "x", url: "   " }).url, null);
+  assert.equal(normalizeProject({ name: "x", url: null }).url, null);
+});
+
+test("normalizeProject rejects links that are not http(s)", () => {
+  assert.equal(normalizeProject({ name: "x", url: "mbb.dev" }).url, null);
+  assert.equal(normalizeProject({ name: "x", url: "javascript:alert(1)" }).url, null);
+  assert.equal(normalizeProject({ name: "x", repo: "github.com/x/y" }).repo, null);
+});
+
+test("normalizeProject defaults description and tags", () => {
+  const project = normalizeProject({ name: "solo" });
+  assert.equal(project.description, null);
+  assert.deepEqual(project.tags, []);
+});
+
+test("normalizeProject drops blank and non-string tags", () => {
+  assert.deepEqual(normalizeProject({ name: "x", tags: ["Elixir", " ", null, 7] }).tags, [
+    "Elixir",
+  ]);
+});
+
+test("selectProjects preserves the hand-written order of the data file", () => {
+  const list = selectProjects([{ name: "ketiga" }, { name: "pertama" }, { name: "kedua" }]);
+
+  assert.deepEqual(
+    list.map((p) => p.name),
+    ["ketiga", "pertama", "kedua"],
+  );
+});
+
+test("selectProjects skips entries without a usable name", () => {
+  const list = selectProjects([{ name: "ok" }, { name: "  " }, null, {}, "bukan objek"]);
+
+  assert.deepEqual(
+    list.map((p) => p.name),
+    ["ok"],
+  );
+});
+
+test("selectProjects tolerates a non-array data file", () => {
+  assert.deepEqual(selectProjects(null), []);
+  assert.deepEqual(selectProjects({ name: "bukan array" }), []);
+});
+
+test("the curated Karya data file is a non-empty, valid list", () => {
+  assert.ok(Array.isArray(karya), "karya.js must export an array");
+  assert.ok(karya.length > 0, "karya.js must not be empty");
+
+  const projects = selectProjects(karya);
+  assert.equal(projects.length, karya.length, "every entry must have a usable name");
+
+  for (const project of projects) {
+    assert.ok(project.description, `"${project.name}" needs an Indonesian description`);
+    assert.ok(project.repo, `"${project.name}" needs a usable GitHub URL`);
+  }
+});


### PR DESCRIPTION
## Intent

Make the hand-curated 'Open Source' section of the existing /showcase ("Karya") page data-driven, and give each project an optional link to where a visitor can actually use it, separate from its GitHub repo link.

Target page: the EXISTING src/showcase.njk at /showcase. An earlier direction to build a NEW /experiment page auto-generated from the GitHub API was explicitly withdrawn by the captain twice — first the data source changed from the GitHub API to a hand-curated list ("my github contain so many unfinish project, let's manually curate it instead of get from github api"), then the page target changed to the existing showcase page ("ah, i forgot about that page, let use that page instead; other than github repo link, i need url to access it as well"). So: NO /experiment page, NO GitHub API, NO network call at build time, NO GITHUB_TOKEN handling, NO pagination/rate-limit/offline-fallback logic, NO committed API cache snapshot, and NO exclude/pin curation knob (curation IS the list now). The built site must contain no /experiment URL, and src/experiment/1-init.md must still build to its own /1-bikin-journaling-app-sederhana/ permalink — that file is unrelated despite its directory and must not be touched. Earlier iterations of the withdrawn approach were reverted in the working tree before the first commit; only the final shape is committed.

Requirements the captain accepted, in their current form:

1. /showcase keeps its URL, its , its intro copy, its two headings ("Open Source" and "Lainnya"), its card design, its badges, and its "Kembali ke halaman utama" link. A reader should NOT notice a redesign. This is deliberately a data-plumbing and content change, not a visual rework — so the rendered markup for the existing five cards is intentionally identical to what the page produced before, apart from the new second link.

2. The "Open Source" cards render from a single hand-curated data file the captain owns and edits directly: src/_data/karya.js. It is the single source of truth for that section. It is deliberately pure data with no computed logic; normalization lives in src/libs/karya.js and is wired in via a Eleventy filter, so the data file stays trivially hand-editable. It was seeded verbatim from the five projects previously hardcoded in showcase.njk (slopcase, mbb, gemini-for-web-dev, workspresso, ai-workshop-material), carrying over their existing names, Indonesian descriptions, GitHub URLs, and tech badges — those are the captain's own words and selection.

3. The data file carries a header comment block in Indonesian explaining exactly how to add, remove, and reorder a project by hand. It is written for a human editing by hand, so it deliberately refers to no code. Card order on the page is deliberately just the order of entries in the file — the captain's hand ordering is meaningful and nothing re-sorts it.

4. The per-entry schema is deliberately small: name (required), description (required, Indonesian), repo (required, GitHub URL), url (optional access link), tags (optional array). A larger schema was explicitly ruled out. An earlier draft had and fields plus status-based grouping; those were dropped when the target became the showcase page, because that page's headings must not change.

5. THE CAPTAIN'S ACTUAL REQUEST: the optional field is where a visitor can use or access the thing, as distinct from its GitHub source. When an entry has one, it renders as a second link on that card with a short Indonesian label ("Coba langsung →"), styled deliberately differently from the card title (mono, uppercase, small) so it is obvious which link is source and which is the live thing. When an entry has none, only the GitHub link renders — no empty link, no placeholder text, no dead anchor, no "coming soon". Both cases are covered by tests.

6. Access URLs are settled facts supplied by the captain, not guesses — no URL was invented. ai-workshop-material -> https://workshop.rizafahmi.com. A sixth project was added last: makan-dimana, repo https://github.com/rizafahmi/makan-dimana, url https://vote.rizafahmi.com; its name is deliberately the repo name to match the file's convention (the captain referred to it conversationally as "Makan dimana"), its Indonesian description matches its neighbours' register and length, and its tags (Astro, TypeScript, Local-first) were chosen from the repo's actual stack rather than raw GitHub language stats, in the same spirit as the other entries. slopcase, mbb, gemini-for-web-dev and workspresso genuinely have NO access URL and are not expected to ever get one — this is a settled answer, which is why their earlier TODO comments were deliberately removed rather than left implying the captain still owes a URL. The header comment's general explanation of the optional field stays, because it is guidance for future entries.

7. The "Lainnya" section of showcase.njk was left completely alone on purpose: it is hand-written HTML of a different shape and explicitly out of scope. It was not converted, reordered, or restyled. The separate hand-maintained content there is the captain's.

8. All page copy is in Indonesian, matching the register of the rest of the site.

9. TDD was mandatory: failing test first, then implementation. test/karya.test.js pins normalization/validation and the file-order guarantee; test/karya-page.test.js pins rendering, including the has-access-url and no-access-url cases, missing optional fields, the empty list, ordering, and escaping. The devDependency was added deliberately and is kept only because test/karya-page.test.js genuinely renders the Nunjucks include with it; it was already present transitively via Eleventy, and it is pinned to the same version (3.2.4) to avoid a duplicate install.

10.
> rizafahmi.com@0.0.1 check
> biome check . && npm test

Checked 31 files in 46ms. No fixes applied.

> rizafahmi.com@0.0.1 test
> node --test test/*.test.js

✔ renders a card with the project name linked to its GitHub repo (6.468ms)
✔ renders tech tags as badges, in order (0.508125ms)
✔ renders a second, separately labelled link when the project has an access url (0.314125ms)
✔ renders only the GitHub link when the project has no access url (0.315459ms)
✔ a project with no tags renders no badges container (0.268334ms)
✔ an empty list renders an empty grid, not broken markup (0.1965ms)
✔ cards render in the order the data file lists them (0.239458ms)
✔ escapes text so a stray character in the data file cannot break the page (0.207583ms)
✔ never renders undefined or null leaking from a missing optional field (0.301542ms)
✔ normalizeProject trims text and keeps the fields the card renders (1.11825ms)
✔ normalizeProject leaves the optional access url empty when there is none (0.578542ms)
✔ normalizeProject rejects links that are not http(s) (0.09775ms)
✔ normalizeProject defaults description and tags (0.08875ms)
✔ normalizeProject drops blank and non-string tags (0.091666ms)
✔ selectProjects preserves the hand-written order of the data file (0.118916ms)
✔ selectProjects skips entries without a usable name (0.094375ms)
✔ selectProjects tolerates a non-array data file (0.070667ms)
✔ the curated Karya data file is a non-empty, valid list (0.180625ms)
✔ visibleTags hides internal collection tags (0.965584ms)
✔ formatOgDate uses Indonesian month abbreviations (0.95775ms)
✔ buildSvg uses Neo-Acid Gallery palette (2.2795ms)
✔ generateOgImage writes a 1200x630 PNG (589.422708ms)
✔ tokenize strips html + stopwords (1.473958ms)
✔ prefers shared tags when available (0.423291ms)
✔ falls back to similarity when no shared tags (0.154917ms)
✔ deterministic tie-breakers: date then url (10.451459ms)
ℹ tests 26
ℹ suites 0
ℹ pass 26
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 728.909583 (biome check + node --test test/*.test.js) must pass, and
> rizafahmi.com@0.0.1 prebuild
> npm run clean


> rizafahmi.com@0.0.1 clean
> npx rimraf dist/


> rizafahmi.com@0.0.1 build
> ELEVENTY_ENV=prod npx @11ty/eleventy && npx pagefind --site dist && npm run audit:site

[11ty] Writing ./dist/feed/full.xml from ./src/feed-full.njk
[11ty] Writing ./dist/feed.xml from ./src/feed.njk
[11ty] Writing ./dist/index.html from ./src/index.njk
[11ty] Writing ./dist/llms-full.txt from ./src/llms-full.njk
[11ty] Writing ./dist/llms.txt from ./src/llms.njk
[11ty] Writing ./dist/_redirects from ./src/redirects.njk
[11ty] Writing ./dist/robots.txt from ./src/robots.njk
[11ty] Writing ./dist/search/index.html from ./src/search.njk
[11ty] Writing ./dist/sitemap.xml from ./src/sitemap.njk
[11ty] Writing ./dist/2017/05/11/5-kebiasaan-coding/index.html from ./src/catatan/5-kebiasaan-coding-yang-menjadikan-kamu-super-developer.md (njk)
[11ty] Writing ./dist/catatan/agentic-coding-bag-2/index.html from ./src/catatan/agentic-coding-bag-2.md (njk)
[11ty] Writing ./dist/catatan/agentic-coding-bag-3/index.html from ./src/catatan/agentic-coding-bag-3.md (njk)
[11ty] Writing ./dist/catatan/agentic-coding/index.html from ./src/catatan/agentic-coding.md (njk)
[11ty] Writing ./dist/tampilan-web/index.html from ./src/catatan/aplikasi-web.md (njk)
[11ty] Writing ./dist/catatan/asisten-ngoding-2/index.html from ./src/catatan/asisten-ngoding-2.md (njk)
[11ty] Writing ./dist/catatan/asisten-ngoding-3/index.html from ./src/catatan/asisten-ngoding-3.md (njk)
[11ty] Writing ./dist/catatan/asisten-ngoding-4/index.html from ./src/catatan/asisten-ngoding-4.md (njk)
[11ty] Writing ./dist/catatan/asisten-ngoding-5/index.html from ./src/catatan/asisten-ngoding-5.md (njk)
[11ty] Writing ./dist/catatan/asisten-ngoding/index.html from ./src/catatan/asisten-ngoding.md (njk)
[11ty] Writing ./dist/catatan/bahasa-fungsional-elixir/index.html from ./src/catatan/bahasa-fungsional-elixir.md (njk)
[11ty] Writing ./dist/2018/09/17/cara-belajar-pemrograman/index.html from ./src/catatan/cara-belajar-pemrograman.md (njk)
[11ty] Writing ./dist/paas-dokku/index.html from ./src/catatan/dokku.md (njk)
[11ty] Writing ./dist/2020/02/03/ekosistemjs/index.html from ./src/catatan/ekosistemjs.md (njk)
[11ty] Writing ./dist/catatan/elixir-struktur-data/index.html from ./src/catatan/elixir-struktur-data.md (njk)
[11ty] Writing ./dist/2018/05/08/f8-san-jose-trip-day-0/index.html from ./src/catatan/f8-san-jose-trip-day-0.md (njk)
[11ty] Writing ./dist/2018/05/21/f8-san-jose-trip-day-2/index.html from ./src/catatan/f8-silicon-valley-day-2.md (njk)
[11ty] Writing ./dist/2018/05/14/f8-san-jose-trip-day-1/index.html from ./src/catatan/f8-silicon-valley-trip-day-1.md (njk)
[11ty] Writing ./dist/2018/05/28/f8-san-jose-trip-day-3-4/index.html from ./src/catatan/f8-silicon-valley-trip-day-3-4.md (njk)
[11ty] Writing ./dist/2021/09/12/tentang-friction-log/index.html from ./src/catatan/friction-log.md (njk)
[11ty] Writing ./dist/gemini-web-dev/index.html from ./src/catatan/gemini.md (njk)
[11ty] Writing ./dist/2018/04/06/kenapa-edukasi-yang-bagus-itu-tidak-murah-harganya/index.html from ./src/catatan/kenapa-edukasi-yang-bagus-itu-tidak-murah-harganya.md (njk)
[11ty] Writing ./dist/2018/08/20/machine-learning-for-web-developers/index.html from ./src/catatan/machine-learning-for-web-developers.md (njk)
[11ty] Writing ./dist/2019/04/29/memahami-beam/index.html from ./src/catatan/memahami-beam.md (njk)
[11ty] Writing ./dist/catatan/membangun-permainan-balap-kode-dgn-ai/index.html from ./src/catatan/membangun-permainan-balap-kode-dgn-ai.md (njk)
[11ty] Writing ./dist/2020/03/21/notasi-o-besar-big-o-notation/index.html from ./src/catatan/notasi-o-besar-big-o-notation.md (njk)
[11ty] Writing ./dist/catatan/notebooklm/index.html from ./src/catatan/notebooklm.md (njk)
[11ty] Writing ./dist/panduan-menulis/index.html from ./src/catatan/panduan-menulis.md (njk)
[11ty] Writing ./dist/catatan/paradigma-fungsional-elixir/index.html from ./src/catatan/paradigma-fungsional-elixir.md (njk)
[11ty] Writing ./dist/catatan/paradigma-pemrograman/index.html from ./src/catatan/paradigma-pemrograman.md (njk)
[11ty] Writing ./dist/2018/12/22/pengalaman-pertama-cds/index.html from ./src/catatan/pengalaman-pertama-cds.md (njk)
[11ty] Writing ./dist/2018/12/10/perkenalan-reasonml/index.html from ./src/catatan/perkenalan-reasonml.md (njk)
[11ty] Writing ./dist/2018/07/12/rangkuman-acara-devc-jakarta-build-day-2018/index.html from ./src/catatan/rangkuman-acara-developer-circles-jakarta-build-day-2018.md (njk)
[11ty] Writing ./dist/rangkuman-how-to-write-a-book/index.html from ./src/catatan/rangkuman-buku-how-to-write-a-book.md (njk)
[11ty] Writing ./dist/2020/03/26/rekursi-atau-recursion/index.html from ./src/catatan/rekursi-atau-recursion.md (njk)
[11ty] Writing ./dist/2018/07/25/screencast-singkat-tentang-tensorflow-js/index.html from ./src/catatan/screencast-singkat-tentang-tensorflow-js.md (njk)
[11ty] Writing ./dist/catatan/til-observer-di-proyek-elixir/index.html from ./src/catatan/til-observer-di-proyek-elixir.md (njk)
[11ty] Writing ./dist/web-scraping/index.html from ./src/catatan/web-scraping.md (njk)
[11ty] Writing ./dist/ekosistemjs/en/index.html from ./src/catatan/ekosistemjs/en.md (njk)
[11ty] Writing ./dist/prompt-journal/index.html from ./src/prompt-journal.md (njk)
[11ty] Writing ./dist/catatan/developer-ai-teman-atau-lawan/index.html from ./src/catatan/developer-ai-teman-atau-lawan.md (njk)
[11ty] Writing ./dist/catatan/digital-garden/index.html from ./src/catatan/digital-garden.md (njk)
[11ty] Writing ./dist/catatan/elixir-phoenix-rest-api/index.html from ./src/catatan/elixir-phoenix-rest-api.md (njk)
[11ty] Writing ./dist/catatan/gemini-3-review/index.html from ./src/catatan/gemini-3-review.md (njk)
[11ty] Writing ./dist/catatan/gemini-3/index.html from ./src/catatan/gemini-3.md (njk)
[11ty] Writing ./dist/catatan/menemukan-kegunaan-obsidian/index.html from ./src/catatan/menemukan-kegunaan-obsidian.md (njk)
[11ty] Writing ./dist/catatan/prototipe-dengan-phoenix/index.html from ./src/catatan/prototipe-dengan-phoenix.md (njk)
[11ty] Writing ./dist/catatan/update-oktober/index.html from ./src/catatan/update-oktober.md (njk)
[11ty] Writing ./dist/catatan/whisper.cpp/index.html from ./src/catatan/whisper.cpp.md (njk)
[11ty] Writing ./dist/1-bikin-journaling-app-sederhana/index.html from ./src/experiment/1-init.md (njk)
[11ty] Writing ./dist/articles/index.html from ./src/articles.njk
[11ty] Writing ./dist/kerjasama/index.html from ./src/ratecard.njk
[11ty] Writing ./dist/showcase/index.html from ./src/showcase.njk
[11ty] Writing ./dist/tags/index.html from ./src/tags.njk
[11ty] Writing ./dist/tags/agentic-coding/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/topik/ai/index.html from ./src/topik/ai.njk
[11ty] Writing ./dist/topik/elixir/index.html from ./src/topik/elixir.njk
[11ty] Writing ./dist/topik/index.html from ./src/topik/index.njk
[11ty] Writing ./dist/topik/produktivitas/index.html from ./src/topik/produktivitas.njk
[11ty] Writing ./dist/topik/web/index.html from ./src/topik/web.njk
[11ty] Writing ./dist/changelog/index.html from ./src/changelog.njk
[11ty] Writing ./dist/now/index.html from ./src/now.njk
[11ty] Writing ./dist/uses/index.html from ./src/uses.njk
[11ty] Writing ./dist/ai/index.html from ./src/ai.md (njk)
[11ty] Writing ./dist/tags/ai/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/algoritma/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/beam/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/belajar/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/bisnis/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/coding/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/computer-science/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/concurrency/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/desain-ui/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/developer/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/devops/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/docker/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/edukasi/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/elixir/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/framework/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/frontend/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/functional-programming/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/hacktiv8/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/javascript/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/komunitas/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/konferensi/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/machine-learning/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/menulis/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/motivasi/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/nodejs/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/opini/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/otp/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/paas/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/panduan/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/paradigma/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/planning/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/produktivitas/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/rangkuman/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/self-hosting/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/spesifikasi/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/struktur-data/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/til/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/tools/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/travel/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/tutorial/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/web/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/web-scraping/index.html from ./src/tags/tag.njk
[11ty] Writing ./dist/tags/workflow/index.html from ./src/tags/tag.njk
[og-image] Generating 34 OG images…
[og-image] Done in 5853ms
[11ty] Copied 365 Wrote 116 files in 40.48 seconds (349.0ms each, v3.1.2)

Running Pagefind v1.4.0 (Extended)
Running from: "/Users/riza/.treehouse/rizafahmi.com-db091f/1/rizafahmi.com"
Source: "dist"
Output: "dist/pagefind"

[Walking source directory]
Found 109 files matching **/*.{html}

[Parsing files]
Found a data-pagefind-body element on the site.
↳ Ignoring pages without this tag.

[Reading languages]
Discovered 1 language: id

[Building search indexes]
Total:
Indexed 1 language
Indexed 53 pages
Indexed 7721 words
Indexed 0 filters
Indexed 0 sorts

Finished in 0.288 seconds

> rizafahmi.com@0.0.1 audit:site
> node scripts/audit-site.mjs

[site-audit] OK must complete including the pagefind and audit:site steps. Both were verified green, and the built /showcase page was confirmed to have six cards with exactly two access links (ai-workshop-material and makan-dimana) and repo-only cards for the other four.

AGENTS.md gained a short 'Curated Data' note pointing at src/_data/karya.js, plus the project's missing '## Maintaining this file' self-governance section. Note that this repo has both a real AGENTS.md and a real CLAUDE.md; reconciling them is pre-existing and deliberately out of scope for this change.

## What Changed
- Drive the /showcase "Open Source" cards from a hand-curated `src/_data/karya.js` list (normalized via `src/libs/karya.js` and a Nunjucks include), keeping page structure, copy, and card design unchanged while leaving "Lainnya" hand-written.
- Add an optional per-project access URL that renders a separate "Coba langsung →" link when present (and nothing when absent); seed access URLs for ai-workshop-material and makan-dimana, and add the makan-dimana project to the curated list.
- Cover normalization and card rendering with unit tests, and document the curated Karya data file in AGENTS.md.

## Risk Assessment

✅ Low: Well-bounded showcase data-plumbing change that matches the accepted intent, preserves page structure and Lainnya content, and keeps normalization/rendering simple with no forbidden /experiment or GitHub API paths.

## Testing

Ran the focused karya unit/page tests (all green), built the site, verified the rendered /showcase HTML and live page (six cards in file order; “Coba langsung →” only for workshop.rizafahmi.com and vote.rizafahmi.com; Lainnya and back link intact; no /experiment URL), captured screenshots, then cleaned dist.

- Evidence: Full /showcase (Karya) page (local file: <code>/var/folders/56/2m6tn38j08j1ypyx86tvpz5c0000gn/T/no-mistakes-evidence/01M0FSEWGF3YJVJDFT91JVBN9T/showcase-full.png</code>)
- Evidence: Open Source card grid with access links (local file: <code>/var/folders/56/2m6tn38j08j1ypyx86tvpz5c0000gn/T/no-mistakes-evidence/01M0FSEWGF3YJVJDFT91JVBN9T/showcase-open-source-cards.png</code>)
<details>
<summary>Evidence: Access-link verification (6 cards, 2 Coba langsung)</summary>

```text
Showcase /showcase/ access links verification
Generated: 2026-08-20 (Asia/Jakarta)

Open Source card grid (.card-grid):
- Total cards: 6
  1. slopcase (https://github.com/rizafahmi/slopcase)
  2. mbb (https://github.com/rizafahmi/mbb)
  3. gemini-for-web-dev (https://github.com/rizafahmi/gemini-for-web-dev)
  4. workspresso (https://github.com/rizafahmi/workspresso)
  5. ai-workshop-material (https://github.com/rizafahmi/ai-workshop-material)
  6. makan-dimana (https://github.com/rizafahmi/makan-dimana)

"Coba langsung" links (a.card-link):
- Count: 2 (expected: 2)
- https://workshop.rizafahmi.com (ai-workshop-material card)
- https://vote.rizafahmi.com (makan-dimana card)

Result: PASS — 6 cards and exactly 2 Coba langsung links confirmed.
```
</details>
<details>
<summary>Evidence: Built HTML assertions for /showcase</summary>

`card_count=6; access_link_count=2; urls=workshop.rizafahmi.com, vote.rizafahmi.com; no /experiment path`

```text
card_count=6
names=slopcase, mbb, gemini-for-web-dev, workspresso, ai-workshop-material, makan-dimana
access_link_count=2
access_urls=https://workshop.rizafahmi.com, https://vote.rizafahmi.com
repos=https://github.com/rizafahmi/slopcase, https://github.com/rizafahmi/mbb, https://github.com/rizafahmi/gemini-for-web-dev, https://github.com/rizafahmi/workspresso, https://github.com/rizafahmi/ai-workshop-material, https://github.com/rizafahmi/makan-dimana
has_open_source_heading=True
has_lainnya_heading=True
has_back_link=True
no_experiment_path=True
```
</details>
<details>
<summary>Evidence: Rendered Open Source HTML fragment</summary>

```text
<h3 style="margin: 1.5rem 0.5rem 0;">Open Source</h3>
  
  <div class="card-grid">
    <div class="card">
      <h3><a href="https://github.com/rizafahmi/slopcase" target="_blank" rel="noopener noreferrer">slopcase</a></h3>
      <p>Showcase untuk proyek AI-generated: submit &amp; voting, “slop atau bukan?”</p>
      <div class="badges" aria-label="Tech stack">
        <span class="badge">Elixir</span>
        <span class="badge">Phoenix LiveView</span>
        <span class="badge">SQLite</span>
      </div>
    </div>
    <div class="card">
      <h3><a href="https://github.com/rizafahmi/mbb" target="_blank" rel="noopener noreferrer">mbb</a></h3>
      <p>CLI assistant sederhana untuk prompt tools &amp; agentic loop di terminal.</p>
      <div class="badges" aria-label="Tech stack">
        <span class="badge">Elixir</span>
        <span class="badge">CLI</span>
        <span class="badge">Anthropic</span>
      </div>
    </div>
    <div class="card">
      <h3><a href="https://github.com/rizafahmi/gemini-for-web-dev" target="_blank" rel="noopener noreferrer">gemini-for-web-dev</a></h3>
      <p>Contoh app Gemini API untuk kebutuhan web developer (#geminisprint).</p>
      <div class="badges" aria-label="Tech stack">
        <span class="badge">Node.js</span>
        <span class="badge">Gemini API</span>
        <span class="badge">Turso</span>
      </div>
    </div>
    <div class="card">
      <h3><a href="https://github.com/rizafahmi/workspresso" target="_blank" rel="noopener noreferrer">workspresso</a></h3>
      <p>Cari coffee shop yang work-friendly, dengan data Wi‑Fi, colokan, noise, dll.</p>
      <div class="badges" aria-label="Tech stack">
        <span class="badge">Astro</span>
        <span class="badge">Node.js</span>
        <span class="badge">SQLite</span>
      </div>
    </div>
    <div class="card">
      <h3><a href="https://github.com/rizafahmi/ai-workshop-material" target="_blank" rel="noopener noreferrer">ai-workshop-material</a></h3>
      <p>Materi workshop AI (DevFest GDG Jogja 2025): skenario AI di luar chatbot.</p>
      <p class="card-links"><a class="card-link" href="https://workshop.rizafahmi.com" target="_blank" rel="noopener noreferrer">Coba langsung &rarr;</a></p>
      <div class="badges" aria-label="Tech stack">
        <span class="badge">Workshop</span>
        <span class="badge">JavaScript</span>
        <span class="badge">LLM</span>
      </div>
    </div>
    <div class="card">
      <h3><a href="https://github.com/rizafahmi/makan-dimana" target="_blank" rel="noopener noreferrer">makan-dimana</a></h3>
      <p>Voting bareng buat nentuin “mau makan di mana?”, dibangun local-first.</p>
      <p class="card-links"><a class="card-link" href="https://vote.rizafahmi.com" target="_blank" rel="noopener noreferrer">Coba langsung &rarr;</a></p>
      <div class="badges" aria-label="Tech stack">
        <span class="badge">Astro</span>
        <span class="badge">TypeScript</span>
        <span class="badge">Local-first</span>
      </div>
    </div>
  </div>


  <hr
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --test test/karya.test.js test/karya-page.test.js`
- <code>`ELEVENTY_ENV=prod npx @11ty/eleventy` then assert built `dist/showcase/index.html` (6 cards, 2 access links, Open Source/Lainnya/back link present)</code>
- <code>Confirm no `dist/experiment` path and `dist/1-bikin-journaling-app-sederhana/index.html` still built from `src/experiment/1-init.md`</code>
- <code>Manual Playwright browse of `http://127.0.0.1:4173/showcase/` with full-page and `.card-grid` screenshots</code>
- <code>`npm run clean` after evidence capture</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `CLAUDE.md:1` - Pre-existing out-of-scope drift: CLAUDE.md and README.md still describe JavaScript Standard Style (and CLAUDE.md still uses the Minimalist Foundry design north star), while AGENTS.md and package.json are Biome + Neo-Acid Gallery. Intent already deferred full AGENTS/CLAUDE reconciliation; worth a dedicated follow-up consolidation rather than syncing copies in this change.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
