### PR TITLE
feat(karya): expand Open Source list to twelve entries

### DIFF
--- a/src/_data/karya.js
+++ b/src/_data/karya.js
@@ -70,4 +70,47 @@ export default [
     url: "https://vote.rizafahmi.com",
     tags: ["Astro", "TypeScript", "Local-first"],
   },
+  {
+    name: "Ngobrolin Web",
+    description: "Landing page podcast Ngobrolin Web: daftar episode dan tautan dengarnya.",
+    repo: "https://github.com/ngobrolin/landing",
+    url: "https://ngobrol.in",
+    tags: ["Astro", "TypeScript", "Podcast"],
+  },
+  {
+    name: "notable",
+    description: "Kotak masukan & tip QRIS buat streamer, lengkap dengan overlay alert untuk OBS.",
+    repo: "https://github.com/rizafahmi/notable",
+    url: "https://feedback.rizafahmi.com",
+    tags: ["Elixir", "Phoenix LiveView", "SQLite"],
+  },
+  {
+    name: "samarin",
+    description:
+      "Samarkan NIK, NPWP, dan data pribadi lain sebelum ditempel ke ChatGPT atau Claude.",
+    repo: "https://github.com/rizafahmi/samarin",
+    url: "https://samarin.rizafahmi.com",
+    tags: ["Astro", "TypeScript", "Local-first"],
+  },
+  {
+    name: "clawdex",
+    description:
+      "Gateway asisten AI pribadi di atas BEAM: ngobrol lewat Telegram, riwayat aman di SQLite.",
+    repo: "https://github.com/rizafahmi/clawdex",
+    tags: ["Elixir", "OTP", "Telegram"],
+  },
+  {
+    name: "evalcode",
+    description:
+      "Contoh utuh bikin eval coding sendiri, dinilai pakai test yang belum pernah dilihat model.",
+    repo: "https://github.com/rizafahmi/evalcode",
+    tags: ["Elixir", "Bash", "LLM Eval"],
+  },
+  {
+    name: "maal",
+    description: "Kalkulator zakat maal dengan harga emas real-time sebagai acuan nisab.",
+    repo: "https://github.com/rizafahmi/maal",
+    url: "https://maal.rizafahmi.com",
+    tags: ["Astro", "TypeScript", "Zakat"],
+  },
 ];

--- a/test/karya-page.test.js
+++ b/test/karya-page.test.js
@@ -93,3 +93,22 @@ test("never renders undefined or null leaking from a missing optional field", ()
 
   assert.doesNotMatch(html, /undefined|\bnull\b/);
 });
+
+test("a repo under a different GitHub org renders exactly like any other card", () => {
+  const html = render([
+    {
+      name: "Ngobrolin Web",
+      description: "Situs Ngobrolin Web.",
+      repo: "https://github.com/ngobrolin/landing",
+      url: "https://ngobrol.in",
+      tags: ["Astro", "TypeScript"],
+    },
+  ]);
+
+  assert.match(
+    html,
+    /<h3><a href="https:\/\/github\.com\/ngobrolin\/landing"[^>]*>Ngobrolin Web<\/a><\/h3>/,
+  );
+  assert.match(html, /href="https:\/\/ngobrol\.in"/);
+  assert.match(html, /class="card-link"/);
+});

--- a/test/karya.test.js
+++ b/test/karya.test.js
@@ -82,3 +82,25 @@ test("the curated Karya data file is a non-empty, valid list", () => {
     assert.ok(project.repo, `"${project.name}" needs a usable GitHub URL`);
   }
 });
+
+test("the curated list carries an entry whose repo lives under another GitHub org", () => {
+  const projects = selectProjects(karya);
+  const ngobrolin = projects.find((p) => p.name === "Ngobrolin Web");
+
+  assert.ok(ngobrolin, "Ngobrolin Web must be in the curated list");
+  assert.equal(ngobrolin.repo, "https://github.com/ngobrolin/landing");
+  assert.equal(ngobrolin.url, "https://ngobrol.in");
+});
+
+test("every curated repo url points at github.com, whatever the owner", () => {
+  for (const project of selectProjects(karya)) {
+    const { hostname } = new URL(project.repo);
+    assert.equal(hostname, "github.com", `"${project.name}" must link to github.com`);
+  }
+
+  const owners = new Set(
+    selectProjects(karya).map((p) => new URL(p.repo).pathname.split("/").filter(Boolean)[0]),
+  );
+  assert.ok(owners.has("rizafahmi"));
+  assert.ok(owners.has("ngobrolin"), "the list is not limited to the captain's own account");
+});


### PR DESCRIPTION
## Intent

Grow the hand-curated "Open Source" list on the Karya page (/showcase) from 6 entries to 12, by appending six new entries to src/_data/karya.js. This is a data-and-content change to one curated file, not a code change.

Entry 1 - Ngobrolin Web:
- repo https://github.com/ngobrolin/landing, url https://ngobrol.in
- name is deliberately "Ngobrolin Web", NOT "landing". This intentionally breaks the file convention of naming an entry after its repo, because the repo is literally called "landing", which is meaningless standing alone. The captain was told and did not object. Do NOT "correct" the name to "landing".
- The org is `ngobrolin`, not `rizafahmi`: this is the first entry in the list whose repo is not under the captain own GitHub account. That is intended.
- GitHub describes the repo as "Landing page untuk Ngobrolin Web Podcast"; stack is TypeScript and Astro. I wrote a one-sentence Indonesian description in the same register and length as its neighbours, and chose tags in the same spirit as existing entries.
- It must NOT mention or link the `ngobrolin_stream` repo. The captain explicitly excluded that repo from the page.

Entries 2-6 - notable, samarin, clawdex, evalcode, maal:
- These five came from a prior curation review where the captain read each one on a visual review surface and accepted all five WITHOUT editing a single description. The approved text (name, description, repo, url, tags) was copied VERBATIM from that report. Do not reword, retranslate, shorten, or "improve" any of these descriptions - it is the captain approved copy, and rewriting it would silently discard a decision they already made. I verified the copy is byte-identical to the report field by field.
- urls: notable -> https://feedback.rizafahmi.com, samarin -> https://samarin.rizafahmi.com, maal -> https://maal.rizafahmi.com (this URL came from the captain directly; the curation pass could not find it from the repo).
- clawdex and evalcode deliberately have NO url (self-hosted gateway; CLI harness). They must render with the GitHub link only and no empty link - the behaviour the data-driven card work already implements and tests.

Settled decisions - do not revisit or propose: the captain considered and DECLINED all five borderline candidates on 2026-08-20: rizafahmi.com, ngobrolin_stream, karyakarsa-widget, shorty-ralph, microblog_ig. Do not add any of them, do not fix karyakarsa-widget install snippet, and do not propose a prompt-journal writeup for shorty-ralph. These were explicit decisions, not oversights.

Ordering: the six new entries are appended AFTER the existing six, in the order above. The order in the curation report was that investigation confidence ordering, not a captain preference, and the captain has expressed no ordering preference. File order is page order, so existing entries must not be sorted, grouped, or reordered.

TDD was applied: the failing tests were written first and confirmed failing before the data was added. test/karya.test.js now pins the Ngobrolin entry repo/url and asserts every curated repo is on github.com with owners including both rizafahmi and ngobrolin (the first cross-org case). test/karya-page.test.js pins that a cross-org repo renders an identical card.

Scope constraint: another worker is concurrently adding Pagefind indexing and llms.txt generation that READS src/_data/karya.js. I deliberately confined myself to the data file and its tests, and did not touch src/showcase.njk, src/libs/karya.js, the includes, llms.njk, or llms-full.njk.

Verification already done: 29/29 tests pass; npm run build passes including pagefind and audit:site; the BUILT dist/showcase/index.html shows 12 cards in the intended order with exactly 6 `class="card-link"` access links, matching the 6 entries that have a url.

Known pre-existing issue, not part of this change: `npm run check` reports one biome formatting error on .claude/settings.local.json, a git-excluded local tooling file. I confirmed by stashing that the clean tree fails identically. My own files are biome-clean (three long descriptions were hand-wrapped to the 100-char line width without altering the string contents).

## What Changed

- Appended six curated Open Source projects to `src/_data/karya.js` (Ngobrolin Web, notable, samarin, clawdex, evalcode, maal), growing the Karya `/showcase` list from 6 to 12 without reordering existing entries
- Included the first cross-org repo (`ngobrolin/landing` as "Ngobrolin Web") plus two repo-only cards (clawdex, evalcode) with no `url`
- Extended `test/karya.test.js` and `test/karya-page.test.js` to pin the Ngobrolin entry and assert cross-org cards render like any other

## Risk Assessment

✅ Low: Well-bounded data-and-test append that matches the stated acceptance criteria with no source-verifiable defects or intent contradictions.

## Testing

After installing dependencies, the focused karya unit/page tests passed, a production build rendered 12 Open Source cards in append order with exactly six access links (clawdex/evalcode GitHub-only; Ngobrolin Web as named under ngobrolin), and live /showcase screenshots confirmed the same end-user UI.

- Evidence: Full /showcase page showing all 12 Open Source cards (local file: <code>/var/folders/56/2m6tn38j08j1ypyx86tvpz5c0000gn/T/no-mistakes-evidence/01M0FX3QN1RWST5K9X5XXTES2G/showcase-full.png</code>)
- Evidence: Open Source grid including Ngobrolin Web through maal (local file: <code>/var/folders/56/2m6tn38j08j1ypyx86tvpz5c0000gn/T/no-mistakes-evidence/01M0FX3QN1RWST5K9X5XXTES2G/showcase-new-entries.png</code>)
- Evidence: clawdex and evalcode cards with GitHub title only (no Coba langsung) (local file: <code>/var/folders/56/2m6tn38j08j1ypyx86tvpz5c0000gn/T/no-mistakes-evidence/01M0FX3QN1RWST5K9X5XXTES2G/showcase-clawdex-evalcode-no-url.png</code>)
- Evidence: Open Source section viewport (local file: <code>/var/folders/56/2m6tn38j08j1ypyx86tvpz5c0000gn/T/no-mistakes-evidence/01M0FX3QN1RWST5K9X5XXTES2G/showcase-open-source-section.png</code>)
<details>
<summary>Evidence: Built-page card inventory: 12 cards, 6 access URLs, declined repos absent</summary>

```text
open_source_cards=12
card_link_total=6

1. slopcase
   repo: https://github.com/rizafahmi/slopcase
   access: (github only — no access url)

2. mbb
   repo: https://github.com/rizafahmi/mbb
   access: (github only — no access url)

3. gemini-for-web-dev
   repo: https://github.com/rizafahmi/gemini-for-web-dev
   access: (github only — no access url)

4. workspresso
   repo: https://github.com/rizafahmi/workspresso
   access: (github only — no access url)

5. ai-workshop-material
   repo: https://github.com/rizafahmi/ai-workshop-material
   access: https://workshop.rizafahmi.com

6. makan-dimana
   repo: https://github.com/rizafahmi/makan-dimana
   access: https://vote.rizafahmi.com

7. Ngobrolin Web
   repo: https://github.com/ngobrolin/landing
   access: https://ngobrol.in

8. notable
   repo: https://github.com/rizafahmi/notable
   access: https://feedback.rizafahmi.com

9. samarin
   repo: https://github.com/rizafahmi/samarin
   access: https://samarin.rizafahmi.com

10. clawdex
   repo: https://github.com/rizafahmi/clawdex
   access: (github only — no access url)

11. evalcode
   repo: https://github.com/rizafahmi/evalcode
   access: (github only — no access url)

12. maal
   repo: https://github.com/rizafahmi/maal
   access: https://maal.rizafahmi.com

clawdex_has_card_link=False
evalcode_has_card_link=False
declined_repos_absent=True
```
</details>
<details>
<summary>Evidence: Rendered Open Source HTML fragment from dist/showcase</summary>

```text
<!DOCTYPE html><html><head><meta charset=utf-8><title>Open Source cards fragment</title></head><body>
<h3>Open Source</h3><div class="card-grid">
    <div class="card">
      <h3><a href="https://github.com/rizafahmi/slopcase" target="_blank" rel="noopener noreferrer">slopcase</a></h3>
      <p>Showcase untuk proyek AI-generated: submit &amp; voting, “slop atau bukan?”</p>
      <div class="badges" aria-label="Tech stack">
        <span class="badge">Elixir</span>
        <span class="badge">Phoenix LiveView</span>
        <span class="badge">SQLite</span>
      </div>
    </div>
    <div class="card">
      <h3><a href="https://github.com/rizafahmi/mbb" target="_blank" rel="noopener noreferrer">mbb</a></h3>
      <p>CLI assistant sederhana untuk prompt tools &amp; agentic loop di terminal.</p>
      <div class="badges" aria-label="Tech stack">
        <span class="badge">Elixir</span>
        <span class="badge">CLI</span>
        <span class="badge">Anthropic</span>
      </div>
    </div>
    <div class="card">
      <h3><a href="https://github.com/rizafahmi/gemini-for-web-dev" target="_blank" rel="noopener noreferrer">gemini-for-web-dev</a></h3>
      <p>Contoh app Gemini API untuk kebutuhan web developer (#geminisprint).</p>
      <div class="badges" aria-label="Tech stack">
        <span class="badge">Node.js</span>
        <span class="badge">Gemini API</span>
        <span class="badge">Turso</span>
      </div>
    </div>
    <div class="card">
      <h3><a href="https://github.com/rizafahmi/workspresso" target="_blank" rel="noopener noreferrer">workspresso</a></h3>
      <p>Cari coffee shop yang work-friendly, dengan data Wi‑Fi, colokan, noise, dll.</p>
      <div class="badges" aria-label="Tech stack">
        <span class="badge">Astro</span>
        <span class="badge">Node.js</span>
        <span class="badge">SQLite</span>
      </div>
    </div>
    <div class="card">
      <h3><a href="https://github.com/rizafahmi/ai-workshop-material" target="_blank" rel="noopener noreferrer">ai-workshop-material</a></h3>
      <p>Materi workshop AI (DevFest GDG Jogja 2025): skenario AI di luar chatbot.</p>
      <p class="card-links"><a class="card-link" href="https://workshop.rizafahmi.com" target="_blank" rel="noopener noreferrer">Coba langsung &rarr;</a></p>
      <div class="badges" aria-label="Tech stack">
        <span class="badge">Workshop</span>
        <span class="badge">JavaScript</span>
        <span class="badge">LLM</span>
      </div>
    </div>
    <div class="card">
      <h3><a href="https://github.com/rizafahmi/makan-dimana" target="_blank" rel="noopener noreferrer">makan-dimana</a></h3>
      <p>Voting bareng buat nentuin “mau makan di mana?”, dibangun local-first.</p>
      <p class="card-links"><a class="card-link" href="https://vote.rizafahmi.com" target="_blank" rel="noopener noreferrer">Coba langsung &rarr;</a></p>
      <div class="badges" aria-label="Tech stack">
        <span class="badge">Astro</span>
        <span class="badge">TypeScript</span>
        <span class="badge">Local-first</span>
      </div>
    </div>
    <div class="card">
      <h3><a href="https://github.com/ngobrolin/landing" target="_blank" rel="noopener noreferrer">Ngobrolin Web</a></h3>
      <p>Landing page podcast Ngobrolin Web: daftar episode dan tautan dengarnya.</p>
      <p class="card-links"><a class="card-link" href="https://ngobrol.in" target="_blank" rel="noopener noreferrer">Coba langsung &rarr;</a></p>
      <div class="badges" aria-label="Tech stack">
        <span class="badge">Astro</span>
        <span class="badge">TypeScript</span>
        <span class="badge">Podcast</span>
      </div>
    </div>
    <div class="card">
      <h3><a href="https://github.com/rizafahmi/notable" target="_blank" rel="noopener noreferrer">notable</a></h3>
      <p>Kotak masukan &amp; tip QRIS buat streamer, lengkap dengan overlay alert untuk OBS.</p>
      <p class="card-links"><a class="card-link" href="https://feedback.rizafahmi.com" target="_blank" rel="noopener noreferrer">Coba langsung &rarr;</a></p>
      <div class="badges" aria-label="Tech stack">
        <span class="badge">Elixir</span>
        <span class="badge">Phoenix LiveView</span>
        <span class="badge">SQLite</span>
      </div>
    </div>
    <div class="card">
      <h3><a href="https://github.com/rizafahmi/samarin" target="_blank" rel="noopener noreferrer">samarin</a></h3>
      <p>Samarkan NIK, NPWP, dan data pribadi lain sebelum ditempel ke ChatGPT atau Claude.</p>
      <p class="card-links"><a class="card-link" href="https://samarin.rizafahmi.com" target="_blank" rel="noopener noreferrer">Coba langsung &rarr;</a></p>
      <div class="badges" aria-label="Tech stack">
        <span class="badge">Astro</span>
        <span class="badge">TypeScript</span>
        <span class="badge">Local-first</span>
      </div>
    </div>
    <div class="card">
      <h3><a href="https://github.com/rizafahmi/clawdex" target="_blank" rel="noopener noreferrer">clawdex</a></h3>
      <p>Gateway asisten AI pribadi di atas BEAM: ngobrol lewat Telegram, riwayat aman di SQLite.</p>
      <div class="badges" aria-label="Tech stack">
        <span class="badge">Elixir</span>
        <span class="badge">OTP</span>
        <span class="badge">Telegram</span>
      </div>
    </div>
    <div class="card">
      <h3><a href="https://github.com/rizafahmi/evalcode" target="_blank" rel="noopener noreferrer">evalcode</a></h3>
      <p>Contoh utuh bikin eval coding sendiri, dinilai pakai test yang belum pernah dilihat model.</p>
      <div class="badges" aria-label="Tech stack">
        <span class="badge">Elixir</span>
        <span class="badge">Bash</span>
        <span class="badge">LLM Eval</span>
      </div>
    </div>
    <div class="card">
      <h3><a href="https://github.com/rizafahmi/maal" target="_blank" rel="noopener noreferrer">maal</a></h3>
      <p>Kalkulator zakat maal dengan harga emas real-time sebagai acuan nisab.</p>
      <p class="card-links"><a class="card-link" href="https://maal.rizafahmi.com" target="_blank" rel="noopener noreferrer">Coba langsung &rarr;</a></p>
      <div class="badges" aria-label="Tech stack">
        <span class="badge">Astro</span>
        <span class="badge">TypeScript</span>
        <span class="badge">Zakat</span>
      </div>
    </div>
  </div>
</body></html>
```
</details>
<details>
<summary>Evidence: Accessibility snapshot confirming 12 headings and 6 COBA LANGSUNG links</summary>

```text
- link "Langsung ke konten utama" [ref=e1]
- heading "👋 Saya Riza!" [level=1, ref=e2]
  - link "👋 Saya Riza!" [ref=e20]
- link "CATATAN" [ref=e21]
- link "TOPIK" [ref=e22]
- link "CARI" [ref=e23]
- button "Toggle Dark Mode" [ref=e3]
- heading "Karya" [level=2, ref=e4]
- heading "Open Source" [level=3, ref=e5]
- heading "slopcase" [level=3, ref=e6]
  - link "slopcase" [ref=e24]
- heading "mbb" [level=3, ref=e7]
  - link "mbb" [ref=e25]
- heading "gemini-for-web-dev" [level=3, ref=e8]
  - link "gemini-for-web-dev" [ref=e26]
- heading "workspresso" [level=3, ref=e9]
  - link "workspresso" [ref=e27]
- heading "ai-workshop-material" [level=3, ref=e10]
  - link "ai-workshop-material" [ref=e28]
- link "COBA LANGSUNG →" [ref=e29]
- heading "makan-dimana" [level=3, ref=e11]
  - link "makan-dimana" [ref=e30]
- link "COBA LANGSUNG →" [ref=e31]
- heading "Ngobrolin Web" [level=3, ref=e12]
  - link "Ngobrolin Web" [ref=e32]
- link "COBA LANGSUNG →" [ref=e33]
- heading "notable" [level=3, ref=e13]
  - link "notable" [ref=e34]
- link "COBA LANGSUNG →" [ref=e35]
- heading "samarin" [level=3, ref=e14]
  - link "samarin" [ref=e36]
- link "COBA LANGSUNG →" [ref=e37]
- heading "clawdex" [level=3, ref=e15]
  - link "clawdex" [ref=e38]
- heading "evalcode" [level=3, ref=e16]
  - link "evalcode" [ref=e39]
- heading "maal" [level=3, ref=e17]
  - link "maal" [ref=e40]
- link "COBA LANGSUNG →" [ref=e41]
- heading "Lainnya" [level=3, ref=e18]
- heading "BOOTCAMP HACKTIV8 Coding bootcamp, dirintis sejak2016." [level=6, ref=e42]
  - link "HACKTIV8 Coding bootcamp, dirintis sejak2016." [ref=e53]
- heading "KURSUS Belajar SvelteJS, membuat aplikasi web donasi online dan integrasi denganpayment gateway." [level=6, ref=e43]
  - link "Belajar SvelteJS, membuat aplikasi web donasi online dan integrasi denganpayment gateway." [ref=e54]
- heading "KURSUS Struktur data dengan JS, belajar fundamental dengan bahasa pemrograman JavaScript." [level=6, ref=e44]
  - link "Struktur data dengan JS, belajar fundamental dengan bahasa pemrograman JavaScript." [ref=e55]
- heading "KURSUS PWA dengan React, belajar implementasi PWA dengan React." [level=6, ref=e45]
  - link "PWA dengan React, belajar implementasi PWA dengan React." [ref=e56]
- heading "PROYEK Carikerja, daftar developer keren yang terkena dampak COVID-19." [level=6, ref=e46]
  - link "Carikerja, daftar developer keren yang terkena dampak COVID-19." [ref=e57]
- heading "LIVE Sesilivestreaming, belajar dan bikin-bikin bareng." [level=6, ref=e47]
  - link "Sesilivestreaming, belajar dan bikin-bikin bareng." [ref=e58]
- heading "PODCAST Ngobrolin Web, podcast mingguan membahas segala hal tentang WEB." [level=6, ref=e48]
  - link "Ngobrolin Web, podcast mingguan membahas segala hal tentang WEB." [ref=e59]
- heading "KOMUNITAS Awesome Speakers Indonesia, daftar developer yang berkenan diundang menjadi narasumber." [level=6, ref=e49]
  - link "Awesome Speakers Indonesia, daftar developer yang berkenan diundang menjadi narasumber." [ref=e60]
- heading "PODCAST Ceritanya Developer Podcast." [level=6, ref=e50]
  - link "Ceritanya Developer Podcast." [ref=e61]
- heading "PODCAST Hikayat Punggawa Teknologi." [level=6, ref=e51]
  - link "Hikayat Punggawa Teknologi." [ref=e62]
- heading "PODCAST AppsCoast, Indonesia Tech Startup Podcast." [level=6, ref=e52]
  - link "AppsCoast, Indonesia Tech Startup Podcast." [ref=e63]
- link "< Kembali ke halaman utama" [ref=e19]
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`npm install` (setup fix for missing nunjucks)</code>
- `node --test test/karya.test.js test/karya-page.test.js`
- <code>`npm run build` then inspect `dist/showcase/index.html` for 12 cards, 6 `card-link`s, order, and declined-repo absence</code>
- <code>Manual browser check of `http://127.0.0.1:3847/showcase/` via `agent-browser` with screenshots of the full page, Open Source section, new entries, and clawdex/evalcode no-url cards</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
