### PR TITLE
feat(karya): add Balap Kode to the curated showcase list

### DIFF
--- a/src/_data/karya.js
+++ b/src/_data/karya.js
@@ -114,4 +114,10 @@ export default [
     url: "https://maal.rizafahmi.com",
     tags: ["Astro", "TypeScript", "Zakat"],
   },
+  {
+    name: "Balap Kode",
+    description: "Permainan adu cepat mengetik buat developer, dengan soal potongan kode dari AI.",
+    repo: "https://github.com/rizafahmi/coderacer",
+    tags: ["Elixir", "Phoenix LiveView", "AI"],
+  },
 ];

--- a/test/karya.test.js
+++ b/test/karya.test.js
@@ -104,3 +104,16 @@ test("every curated repo url points at github.com, whatever the owner", () => {
   assert.ok(owners.has("rizafahmi"));
   assert.ok(owners.has("ngobrolin"), "the list is not limited to the captain's own account");
 });
+
+test("the curated list carries an entry whose display name differs from its repo name", () => {
+  const projects = selectProjects(karya);
+  const balapKode = projects.find((p) => p.name === "Balap Kode");
+
+  assert.ok(balapKode, "Balap Kode must be in the curated list");
+  assert.equal(balapKode.repo, "https://github.com/rizafahmi/coderacer");
+  assert.equal(
+    balapKode.url,
+    null,
+    "balapkode.com no longer resolves, so the entry stays repo-link-only",
+  );
+});


### PR DESCRIPTION
## Intent

Add one project - Balap Kode - to the curated Karya list at src/_data/karya.js, taking it from 12 entries to 13. This is a small content-shaped change; the care goes into the description, not the plumbing.

The entry, exactly as specified:
- name: 'Balap Kode'. This deliberately breaks the file's repo-name convention and that is the captain's explicit instruction. The repo is called 'coderacer', but 'Balap Kode' is the name the project shipped under and what the captain calls it in their own writing. The same exception already exists in the file for 'Ngobrolin Web', whose repo is unhelpfully named 'landing'. Do NOT 'correct' the name to match the repo.
- repo: https://github.com/rizafahmi/coderacer
- url: omitted entirely, on purpose. The project ran at balapkode.com, which no longer resolves (verified: no A record, no www record, 'Could not resolve host'). The captain chose to leave it link-free for now rather than wait. It therefore renders repo-link-only, exactly like the existing 'clawdex' and 'evalcode' entries, and the existing optional-field handling in src/libs/karya.js already covers it. Do NOT add an empty url, a placeholder, or the dead domain.
- tags: two or three, in the same spirit as neighbouring entries - a mix of language and framework rather than an exhaustive stack list. I chose ['Elixir', 'Phoenix LiveView', 'AI'], mirroring the Elixir/Phoenix LiveView pairing already used by the slopcase and notable entries, with AI in the third slot because AI-generated challenges are what distinguish this from an ordinary typing game.
- position: appended last. File order is page order and the captain did not ask for different placement.
- description: one concise Indonesian sentence matching the register and length of its neighbours, calibrated against the existing twelve, which are the captain's own voice. Source material was the captain's own June 2025 article src/catatan/membangun-permainan-balap-kode-dgn-ai.md plus the repo README. I wrote 'Permainan adu cepat mengetik buat developer, dengan soal potongan kode dari AI.' - deliberately one idea rather than a feature list, and deliberately not a literal translation of the English repo description. The colloquial 'buat developer' matches the register of neighbours like notable ('buat streamer') and makan-dimana ('buat nentuin').

Scope was restricted to src/_data/karya.js and its tests, nothing else. src/showcase.njk, the includes, src/libs/karya.js and the llms templates were explicitly out of scope and are untouched. The coderacer repository itself was explicitly not to be modified - its GitHub homepage field still points at the dead domain, which is flagged separately for the captain and is not mine to change.

TDD was required: extend existing test/karya.test.js / test/karya-page.test.js coverage where this genuinely adds a case, failing test first. I added one test to test/karya.test.js, confirmed red first ('Balap Kode must be in the curated list'), then green. It covers a case the suite genuinely lacked: a curated entry that is deliberately link-free, asserting url === null with the dead-domain reason in the assertion message. I deliberately did NOT duplicate the existing 'Ngobrolin Web' test, which already covers a repo under a different GitHub org, and I added nothing to test/karya-page.test.js because its 'renders only the GitHub link when the project has no access url' test already covers the no-url rendering path generically.

Verification was required against the built HTML rather than the source. Baseline before the change: 12 'class="card"' and 6 'class="card-link"' in dist/showcase/index.html. After: 13 cards, 6 access links - Balap Kode adds a card but no 'Coba langsung' link, exactly as intended. pnpm run build exits 0 with [site-audit] OK, and node --test test/*.test.js passes 64/64.

One known pre-existing failure the reviewer should not attribute to this change: 'pnpm run check' fails, but on the clean tree too. I verified this by stashing my work and re-running 'biome check .' on unmodified HEAD - same failure. It is biome tripping on .claude/settings.local.json, a gitignored file the firstmate harness writes into the worktree, plus a schema-version notice on biome.json (config says 2.4.16, CLI is 2.5.9). Biome passes cleanly on both files I actually touched, and the 'pnpm test' half of check passes. Fixing that is out of scope for this task.

The project moved to pnpm today, so pnpm is the only supported package manager here - not npm, not bun.

I also skipped AGENTS.md: this change produced no durable project-intrinsic knowledge worth recording, and fm-ensure-agents-md.sh reports a pre-existing conflict (both AGENTS.md and CLAUDE.md exist as real files) that is a separate reconciliation outside this task's scope.

Note that another worker is concurrently changing package.json and pnpm-lock.yaml on this repo (a sharp/eleventy-img upgrade), so an ordinary rebase against that is expected.

## What Changed
- Appended Balap Kode to `src/_data/karya.js` (12 → 13 curated Open Source entries), with repo `rizafahmi/coderacer`, Elixir/Phoenix LiveView/AI tags, and no live `url` so it renders repo-link-only.
- Extended `test/karya.test.js` to assert the display name, repo URL, and intentional `url === null` for that entry.

## Risk Assessment

✅ Low: Well-bounded content addition that matches the stated acceptance criteria exactly, reuses existing optional-url handling, and introduces no new plumbing risk.

## Testing

Focused karya unit/page tests passed; production build produced a 13-card showcase with still only 6 access links; screenshots and card HTML show Balap Kode last, repo-link-only, with the specified Indonesian description and Elixir / Phoenix LiveView / AI tags.

- Evidence: Full /showcase page with Balap Kode as 13th Open Source card (local file: <code>/var/folders/56/2m6tn38j08j1ypyx86tvpz5c0000gn/T/no-mistakes-evidence/01M0HCH0XWJ3RQT9H1FC76V71J/showcase-full.png</code>)
- Evidence: Cropped showcase grid showing Balap Kode last without Coba langsung (local file: <code>/var/folders/56/2m6tn38j08j1ypyx86tvpz5c0000gn/T/no-mistakes-evidence/01M0HCH0XWJ3RQT9H1FC76V71J/balap-kode-in-showcase.png</code>)
- Evidence: Styled Balap Kode card (name, description, tags, no access link) (local file: <code>/var/folders/56/2m6tn38j08j1ypyx86tvpz5c0000gn/T/no-mistakes-evidence/01M0HCH0XWJ3RQT9H1FC76V71J/balap-kode-card.png</code>)
<details>
<summary>Evidence: Rendered Balap Kode card HTML snippet from dist/showcase</summary>

```text
<div class="card">
      <h3><a href="https://github.com/rizafahmi/coderacer" target="_blank" rel="noopener noreferrer">Balap Kode</a></h3>
      <p>Permainan adu cepat mengetik buat developer, dengan soal potongan kode dari AI.</p>
      <div class="badges" aria-label="Tech stack">
        <span class="badge">Elixir</span>
        <span class="badge">Phoenix LiveView</span>
        <span class="badge">AI</span>
      </div>
    </div>
```
</details>
<details>
<summary>Evidence: Built showcase card vs card-link counts</summary>

<code>class=&#34;card&#34; count: 13&#10;class=&#34;card-link&#34; count: 6&#10;Balap Kode last; repo-only; no Coba langsung</code>

```text
dist/showcase/index.html after pnpm run build:
  class="card" count: 13
  class="card-link" count: 6
Expected (from intent): 13 cards, 6 access links — Balap Kode adds a card but no "Coba langsung" link.
Balap Kode is last Open Source card; title links to https://github.com/rizafahmi/coderacer; no balapkode.com / card-link.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --test test/karya.test.js test/karya-page.test.js`
- <code>`pnpm run build` then counted `class=&#34;card&#34;` / `class=&#34;card-link&#34;` in `dist/showcase/index.html` (13 / 6)</code>
- <code>Asserted last Open Source card HTML is Balap Kode → `https://github.com/rizafahmi/coderacer`, description/tags present, no `Coba langsung` / `balapkode.com`</code>
- <code>`node --input-type=module` check: `selectProjects(karya)` length 13, last name Balap Kode, `url === null`, source omits `url` key</code>
- <code>Headless Chrome Canary screenshots of `/showcase/` and isolated Balap Kode card</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
