### PR TITLE
feat(cv): add bilingual print-ready CV at /cv/ and /cv/en/

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,12 +71,14 @@ src/
   articles.njk       # Articles listing with pagination
   search.njk         # Search page
   showcase.njk       # Portfolio showcase
+  cv.njk             # CV; one template, two pages (/cv/ and /cv/en/)
   now.njk            # /now page
   uses.njk           # /uses page
 assets/
   global.css         # Site-wide styles
   home.css           # Homepage-specific styles
   tulisan.css        # Article page styles
+  cv.css             # CV screen styles + the @media print rules for /cv/
   fonts/             # Self-hosted fonts
   images/            # Static images
 test/
@@ -136,6 +138,27 @@ See `DESIGN.md` for the full design spec. Key rules:
   generated project entries in `/llms.txt` and `/llms-full.txt` (via
   `src/_includes/karya_llms.njk`). The "Lainnya" section on `/showcase` is still
   hand-written HTML in `src/showcase.njk`.
+- CV content is curated in `src/_data/cv.js` (Indonesian header explains the editing
+  rules). One template, `src/cv.njk`, paginates over `cv.languages` to emit `/cv/` and
+  `/cv/en/` from that single file, so the two languages cannot drift; the shared markup
+  is `src/_includes/cv_body.njk` and the formatting helpers are `src/libs/cv.js`. The 13
+  open source entries are pulled live from `karya.js`, not copied.
+
+## Page Language
+
+The site is Indonesian-first: `main.njk`, `tulisan.njk`, and `serial.njk` all hardcode
+`<html lang="id">`, which is correct for every page they serve. A page in another
+language needs its own layout (see `src/_includes/cv.njk`) and should set these page-data
+fields, which `head.njk` reads with Indonesian defaults:
+
+| Field         | Effect                                            |
+| ------------- | ------------------------------------------------- |
+| `pageLocale`  | `og:locale` (default `id_ID`)                     |
+| `pageLangTag` | `inLanguage` on the WebPage JSON-LD node          |
+| `alternates`  | List of `{ hreflang, href }` for `rel="alternate"` |
+
+Site chrome stays in Indonesian on those pages; mark the wrapper `lang="id"` so screen
+readers do not read it as English.
 
 ## Search
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ src/
   catatan/          # Blog articles in Markdown
   _data/            # Global data files (goatcounter views, etc.)
   _includes/        # Shared Nunjucks partials and layouts
-  libs/             # Custom libraries (shiki, related posts, OG images, internal links)
+  libs/             # Shared JS helpers (cv, karya, shiki, related posts, OG, internal links)
   tags/             # Tag listing pages
   topik/            # Topic hub pages
   index.njk          # Homepage
@@ -141,8 +141,8 @@ See `DESIGN.md` for the full design spec. Key rules:
 - CV content is curated in `src/_data/cv.js` (Indonesian header explains the editing
   rules). One template, `src/cv.njk`, paginates over `cv.languages` to emit `/cv/` and
   `/cv/en/` from that single file, so the two languages cannot drift; the shared markup
-  is `src/_includes/cv_body.njk` and the formatting helpers are `src/libs/cv.js`. The 13
-  open source entries are pulled live from `karya.js`, not copied.
+  is `src/_includes/cv_body.njk` and the formatting helpers are `src/libs/cv.js`. Open
+  source entries are pulled live from `karya.js`, not copied.
 
 ## Page Language
 

--- a/assets/cv.css
+++ b/assets/cv.css
@@ -180,6 +180,20 @@
   margin-bottom: 0.375rem;
 }
 
+.cv-status {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border: 1.5px solid currentColor;
+  padding: 0.05em 0.4em;
+  margin-left: 0.35rem;
+  vertical-align: baseline;
+  white-space: nowrap;
+}
+
 .cv-skills {
   margin: 0;
   display: grid;
@@ -373,6 +387,16 @@ a.back {
   .cv-skills dt,
   .cv-updated {
     color: #333333 !important;
+  }
+
+  /* Status kanal: teks + border, bukan warna latar — printer sering drop background. */
+  .cv-status {
+    color: #000000 !important;
+    background: none !important;
+    border: 1pt solid #000000;
+    font-weight: 700;
+    font-size: 7.5pt;
+    padding: 0 0.35em;
   }
 
   /*

--- a/assets/cv.css
+++ b/assets/cv.css
@@ -1,0 +1,478 @@
+/*
+ * Halaman CV (/cv/ dan /cv/en/).
+ *
+ * Dua tampilan dari satu markup:
+ *   - di layar, mengikuti sistem desain situs (font, warna, mode gelap) lewat
+ *     custom property di assets/global.css;
+ *   - di kertas, jadi dokumen sendiri: hitam di atas putih, tanpa chrome situs,
+ *     dan dijaga supaya satu entri tidak terbelah antar halaman.
+ *
+ * Blok @media print di bawah adalah bagian yang sebenarnya dikirim ke PDF, jadi
+ * perlakukan dia sebagai deliverable, bukan tambahan.
+ */
+
+/* ---------------------------------------------------------------- layar --- */
+
+.cv-main {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.cv-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 2.5rem;
+}
+
+.cv-button {
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.625rem 1rem;
+  border: 2px solid var(--border-color);
+  border-bottom: 2px solid var(--border-color);
+  background: transparent;
+  color: var(--text-color);
+  cursor: pointer;
+  line-height: 1.2;
+}
+
+.cv-button:hover {
+  background-color: var(--accent-acid);
+  color: #0a0b0d;
+  border-color: var(--border-color);
+}
+
+[data-theme="dark"] .cv-button:hover {
+  background-color: var(--accent-cobalt);
+  color: #ffffff;
+}
+
+.cv-header {
+  border-bottom: 4px solid var(--border-color);
+  padding-bottom: 1.75rem;
+  margin-bottom: 1rem;
+}
+
+.cv-name {
+  margin: 0 0 0.5rem;
+}
+
+.cv-headline {
+  font-family: var(--font-mono);
+  font-size: 0.9375rem;
+  color: var(--meta-color);
+  margin: 0 0 1.25rem;
+}
+
+.cv-contact {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+  gap: 0.375rem 1.5rem;
+  font-size: 0.9375rem;
+}
+
+.cv-contact li {
+  display: flex;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.cv-contact a {
+  overflow-wrap: anywhere;
+}
+
+.cv-contact-label,
+.cv-inline-label {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--meta-color);
+  flex: 0 0 5.5rem;
+  padding-top: 0.25rem;
+}
+
+.cv-section {
+  border-top: 2px solid var(--border-color);
+  padding-top: 0.5rem;
+  margin-top: 2.5rem;
+}
+
+/* Bagian pertama menempel langsung di bawah garis tebal kepala CV, jadi tidak
+   perlu garis sendiri — kalau tidak, ada dua garis bertumpuk. */
+.cv-header + .cv-section {
+  border-top: none;
+  padding-top: 0;
+  margin-top: 2rem;
+}
+
+.cv-section > h2 {
+  font-size: clamp(1.25rem, 3vw, 1.625rem);
+  margin: 0 0 1.25rem;
+}
+
+.cv-subhead {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--meta-color);
+  margin: 1.75rem 0 0.75rem;
+}
+
+.cv-entry {
+  margin-bottom: 1.75rem;
+}
+
+.cv-entry:last-child {
+  margin-bottom: 0;
+}
+
+.cv-org {
+  font-size: 1.125rem;
+  letter-spacing: -0.02em;
+  margin: 0 0 0.25rem;
+}
+
+.cv-role {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.25rem 1rem;
+  margin: 0 0 0.25rem;
+  font-size: 0.9375rem;
+}
+
+.cv-role-title {
+  font-weight: 700;
+}
+
+.cv-period {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--meta-color);
+  white-space: nowrap;
+}
+
+.cv-summary {
+  margin: 0.5rem 0 0.5rem;
+  font-size: 0.9375rem;
+}
+
+.cv-highlights,
+.cv-list {
+  margin: 0.5rem 0 0;
+  padding-left: 1.25rem;
+  font-size: 0.9375rem;
+}
+
+.cv-highlights li,
+.cv-list li {
+  margin-bottom: 0.375rem;
+}
+
+.cv-skills {
+  margin: 0;
+  display: grid;
+  gap: 0.625rem;
+}
+
+.cv-skill-group {
+  display: grid;
+  grid-template-columns: minmax(0, 12.5rem) minmax(0, 1fr);
+  gap: 0.25rem 1rem;
+  align-items: baseline;
+}
+
+@media (max-width: 600px) {
+  .cv-skill-group {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .cv-contact-label,
+  .cv-inline-label {
+    flex-basis: 4.5rem;
+  }
+}
+
+.cv-skills dt {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--meta-color);
+}
+
+.cv-skills dd {
+  margin: 0;
+  font-size: 0.9375rem;
+}
+
+.cv-tally {
+  font-size: 0.9375rem;
+  margin-bottom: 0.75rem;
+}
+
+.cv-inline {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem 0.75rem;
+  font-size: 0.9375rem;
+  margin-bottom: 0.75rem;
+}
+
+.cv-inline-label {
+  flex: 0 0 auto;
+}
+
+.cv-projects .cv-project {
+  margin-bottom: 0.5rem;
+}
+
+.cv-tags {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  color: var(--meta-color);
+  margin-left: 0.5rem;
+}
+
+.cv-updated {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--meta-color);
+  margin: 2.5rem 0 0;
+}
+
+a.back {
+  display: inline-block;
+  margin-top: 2.5rem;
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  border-bottom: 2px solid var(--link-color);
+}
+
+/* ---------------------------------------------------------------- cetak --- */
+
+@media print {
+  /*
+   * A4 dengan margin 15mm: cukup lebar untuk dipegang printer mana pun,
+   * dan tetap masuk akal kalau yang tersedia justru kertas Letter (Letter
+   * lebih pendek tapi lebih lebar, jadi isinya tidak pernah terpotong).
+   */
+  @page {
+    size: A4;
+    /* Longhand, bukan shorthand: linter menganggap `margin` di @page menimpa
+       margin-top milik aturan lain di atasnya. */
+    margin-top: 15mm;
+    margin-right: 15mm;
+    margin-bottom: 15mm;
+    margin-left: 15mm;
+  }
+
+  /*
+   * Banyak printer mematikan warna latar secara bawaan, jadi halaman ini
+   * memang dirancang hitam di atas putih — bukan sekadar versi gelap yang
+   * dibalik. Tidak ada informasi yang cuma dibedakan lewat warna.
+   */
+  html,
+  body.cv-page {
+    background: #ffffff !important;
+    color: #000000 !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    font-size: 10pt;
+    line-height: 1.42;
+  }
+
+  /* Semua yang sifatnya navigasi, bukan isi. */
+  .skip-link,
+  .site-header,
+  .theme-toggle,
+  .cv-toolbar,
+  a.back,
+  footer,
+  #utterances-container {
+    display: none !important;
+  }
+
+  .cv-main {
+    max-width: none;
+    margin: 0;
+  }
+
+  .cv h1,
+  .cv h2,
+  .cv h3,
+  .cv dt,
+  .cv strong {
+    color: #000000 !important;
+  }
+
+  /* Di kertas tautan tidak bisa diklik, jadi jangan bergaya seperti tautan. */
+  .cv a {
+    color: #000000 !important;
+    text-decoration: none !important;
+    border-bottom: none !important;
+    background: none !important;
+  }
+
+  /* Kecuali tautan profil: teksnya memang alamatnya sendiri, biarkan menonjol. */
+  .cv-contact a.print-url {
+    text-decoration: underline !important;
+    text-underline-offset: 2px;
+  }
+
+  .cv-name {
+    font-size: 22pt;
+    margin-bottom: 0.15rem;
+  }
+
+  .cv-headline {
+    font-size: 10pt;
+    color: #000000 !important;
+    margin-bottom: 0.5rem;
+  }
+
+  .cv-header {
+    border-bottom: 1.5pt solid #000000;
+    padding-bottom: 0.5rem;
+    margin-bottom: 0;
+  }
+
+  .cv-contact {
+    font-size: 9pt;
+    gap: 0.15rem 1.5rem;
+    /* Dua kolom, bukan tiga: alamat sepanjang linkedin.com/in/rizafahmi harus
+       muat utuh dalam satu baris, karena di kertas tidak bisa diklik. */
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .cv-contact a {
+    overflow-wrap: normal;
+  }
+
+  .cv-contact-label {
+    flex-basis: 4.5rem;
+    padding-top: 0;
+  }
+
+  .cv-contact-label,
+  .cv-inline-label,
+  .cv-period,
+  .cv-tags,
+  .cv-subhead,
+  .cv-skills dt,
+  .cv-updated {
+    color: #333333 !important;
+  }
+
+  /*
+   * Paginasi. Judul bagian tidak boleh tertinggal sendirian di kaki halaman,
+   * dan satu entri pekerjaan tidak boleh terbelah di tengah.
+   */
+  .cv-section {
+    border-top: 1pt solid #000000;
+    margin-top: 12pt;
+    padding-top: 4pt;
+    break-inside: auto;
+  }
+
+  .cv-section > h2 {
+    font-size: 12pt;
+    margin: 0 0 6pt;
+    break-after: avoid;
+    break-inside: avoid;
+  }
+
+  .cv-subhead {
+    margin: 10pt 0 4pt;
+    break-after: avoid;
+  }
+
+  .cv-entry,
+  .cv-skill-group,
+  .cv-inline {
+    break-inside: avoid;
+  }
+
+  /*
+   * Daftar open source pendek-pendek tapi banyak. Kalau dibiarkan, tiga
+   * baris pertama nyangkut di kaki halaman sebelumnya. Kalau memang tidak
+   * muat sehalaman pun, browser tetap memecahnya — ini preferensi, bukan
+   * paksaan.
+   */
+  .cv-projects,
+  .cv-projects-extra {
+    break-inside: avoid;
+  }
+
+  .cv-entry {
+    margin-bottom: 10pt;
+  }
+
+  .cv-org {
+    font-size: 11pt;
+    break-after: avoid;
+  }
+
+  .cv-role {
+    font-size: 10pt;
+    margin-bottom: 1pt;
+    break-after: avoid;
+    break-inside: avoid;
+  }
+
+  .cv-summary,
+  .cv-highlights,
+  .cv-list,
+  .cv-skills dd,
+  .cv-tally,
+  .cv-inline {
+    font-size: 9.5pt;
+  }
+
+  .cv-summary {
+    margin: 2pt 0;
+  }
+
+  .cv-highlights,
+  .cv-list {
+    margin-top: 2pt;
+  }
+
+  .cv-highlights li,
+  .cv-list li {
+    margin-bottom: 1pt;
+    break-inside: avoid;
+  }
+
+  .cv-skills {
+    gap: 3pt;
+  }
+
+  /* Kolom label diberi lebar tetap supaya "DATA & INFRASTRUCTURE" muat sebaris. */
+  .cv-skill-group {
+    grid-template-columns: 42mm minmax(0, 1fr);
+  }
+
+  .cv-updated {
+    margin-top: 12pt;
+    font-size: 8pt;
+  }
+
+  /* Baris tunggal yang terdampar di ujung halaman. */
+  .cv p,
+  .cv li {
+    orphans: 3;
+    widows: 3;
+  }
+}

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -2,7 +2,7 @@ import fs, { existsSync } from "node:fs";
 import path from "node:path";
 import Image from "@11ty/eleventy-img";
 import pluginRss from "@11ty/eleventy-plugin-rss";
-import { formatMonth, formatPeriod, translate } from "./src/libs/cv.js";
+import { formatMonth, formatPeriod, orderedChannels, translate } from "./src/libs/cv.js";
 import { selectProjects } from "./src/libs/karya.js";
 import { generateOgImage } from "./src/libs/og-image.js";
 import { getRelatedPosts } from "./src/libs/related.js";
@@ -143,6 +143,7 @@ export default function (eleventyConfig) {
   eleventyConfig.addFilter("translate", translate);
   eleventyConfig.addFilter("cvPeriod", formatPeriod);
   eleventyConfig.addFilter("cvMonth", formatMonth);
+  eleventyConfig.addFilter("orderedChannels", orderedChannels);
 
   eleventyConfig.addFilter("jsonify", (value) => {
     return JSON.stringify(value ?? "");

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -2,6 +2,7 @@ import fs, { existsSync } from "node:fs";
 import path from "node:path";
 import Image from "@11ty/eleventy-img";
 import pluginRss from "@11ty/eleventy-plugin-rss";
+import { formatMonth, formatPeriod, translate } from "./src/libs/cv.js";
 import { selectProjects } from "./src/libs/karya.js";
 import { generateOgImage } from "./src/libs/og-image.js";
 import { getRelatedPosts } from "./src/libs/related.js";
@@ -136,6 +137,12 @@ export default function (eleventyConfig) {
   // Curated projects from src/_data/karya.js (showcase cards + LLM indexes);
   // this only cleans the entries up, it never reorders them.
   eleventyConfig.addFilter("karyaProjects", (projects) => selectProjects(projects));
+
+  // CV pages (/cv/ and /cv/en/). Both languages render from src/_data/cv.js
+  // through src/_includes/cv_body.njk, so these only format what is already there.
+  eleventyConfig.addFilter("translate", translate);
+  eleventyConfig.addFilter("cvPeriod", formatPeriod);
+  eleventyConfig.addFilter("cvMonth", formatMonth);
 
   eleventyConfig.addFilter("jsonify", (value) => {
     return JSON.stringify(value ?? "");

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -134,7 +134,7 @@ export default function (eleventyConfig) {
     return d.toISOString();
   });
 
-  // Curated projects from src/_data/karya.js (showcase cards + LLM indexes);
+  // Curated projects from src/_data/karya.js (showcase, CV, and LLM indexes);
   // this only cleans the entries up, it never reorders them.
   eleventyConfig.addFilter("karyaProjects", (projects) => selectProjects(projects));
 

--- a/src/_data/cv.js
+++ b/src/_data/cv.js
@@ -1,0 +1,487 @@
+/**
+ * ISI CV — dipakai oleh dua halaman sekaligus: /cv/ (Indonesia) dan /cv/en/ (Inggris)
+ * =================================================================================
+ *
+ * File ini murni daftar, sama seperti src/_data/karya.js: tidak ada logika apa pun.
+ * Edit isinya lalu jalankan `pnpm run build` (atau `pnpm start`), dan kedua halaman
+ * CV ikut berubah. Formatnya (tanggal, urutan, terjemahan) diurus
+ * src/libs/cv.js dan src/_includes/cv_body.njk.
+ *
+ * KENAPA SATU FILE UNTUK DUA BAHASA
+ *   Kalau versi Indonesia dan Inggris ditulis terpisah, keduanya pasti melenceng
+ *   begitu salah satunya diedit. Di sini setiap kalimat ditulis sebagai pasangan
+ *   `{ id: "...", en: "..." }`, jadi menambah satu baris berarti menambahnya di
+ *   kedua halaman sekaligus. Kalau isinya sama persis di dua bahasa (nama
+ *   teknologi, nama perusahaan, nama sekolah), cukup tulis string biasa.
+ *
+ * ATURAN TANGGAL
+ *   Tulis "YYYY-MM" kalau tahu bulannya, "YYYY" kalau cuma tahu tahunnya.
+ *   Untuk peran yang masih berjalan, tulis `end: null` — halaman yang menuliskan
+ *   "Sekarang"/"Present", jadi tidak ada durasi basi yang perlu diperbarui manual.
+ *   JANGAN menulis durasi ("7 tahun 1 bulan") di sini; itu selalu jadi salah.
+ *
+ * ATURAN DATA PRIBADI
+ *   Halaman ini publik dan permanen. Email adalah satu-satunya detail pribadi
+ *   yang boleh tampil. TIDAK ADA nomor telepon dan TIDAK ADA lokasi/alamat —
+ *   termasuk di meta tag dan structured data. Alamat yang sudah terlanjur
+ *   di-scrape tidak bisa ditarik kembali. Ada test yang menjaga ini
+ *   (test/cv.test.js dan test/cv-page.test.js).
+ *
+ * ATURAN TAUTAN
+ *   Cek dulu tautannya masih hidup sebelum ditulis di sini. Satu CV yang
+ *   memajang tautan mati lebih buruk daripada CV tanpa tautan sama sekali.
+ *
+ * DAFTAR PROYEK
+ *   13 proyek open source di halaman CV diambil langsung dari src/_data/karya.js,
+ *   tidak disalin ke sini. Tambah proyek di sana, CV ikut terisi.
+ */
+
+export default {
+  /** Bahasa yang diterbitkan. Menambah bahasa berarti menambah halaman di src/. */
+  languages: ["id", "en"],
+
+  /**
+   * Judul, deskripsi, dan alamat tiap versi. `title` juga jadi nama berkas PDF
+   * ketika halaman ini dicetak dari browser, jadi tulis yang enak dibaca.
+   */
+  meta: {
+    id: {
+      permalink: "/cv/",
+      htmlLang: "id", // untuk atribut lang="" dan hreflang=""
+      langTag: "id-ID", // untuk structured data (schema.org inLanguage)
+      ogLocale: "id_ID",
+      title: "CV Riza Fahmi",
+      description:
+        "Riwayat kerja, pendidikan, dan karya Riza Fahmi — co-founder Hacktiv8, pengajar, dan pembuat konten pemrograman. Siap dibaca di layar maupun dicetak jadi PDF.",
+      languageName: "Bahasa Indonesia",
+      // Teks tombol dan tautan di sekeliling CV (bukan isi CV-nya).
+      ui: {
+        print: "Cetak / simpan PDF",
+        back: "Kembali ke halaman utama",
+        toolbar: "Aksi halaman",
+      },
+    },
+    en: {
+      permalink: "/cv/en/",
+      htmlLang: "en",
+      langTag: "en-US",
+      ogLocale: "en_US",
+      title: "Riza Fahmi - CV",
+      description:
+        "The work history, education, and public work of Riza Fahmi — co-founder of Hacktiv8, educator, and programming content creator. Reads on screen and prints straight to PDF.",
+      languageName: "English",
+      ui: {
+        print: "Print / save as PDF",
+        back: "Back to the home page",
+        toolbar: "Page actions",
+      },
+    },
+  },
+
+  /** Bulan terakhir isi CV ini disunting. Tampil sebagai "Diperbarui …". */
+  updated: "2026-08",
+
+  identity: {
+    name: "Riza Fahmi",
+    headline: {
+      id: "Co-Founder di Hacktiv8 Indonesia",
+      en: "Co-Founder at Hacktiv8 Indonesia",
+    },
+    email: "rizafahmi@gmail.com",
+    // Semua tautan di bawah sudah publik. Urutannya = urutan tampil.
+    profiles: [
+      { label: { id: "Situs", en: "Website" }, url: "https://rizafahmi.com" },
+      { label: "GitHub", url: "https://github.com/rizafahmi" },
+      { label: "LinkedIn", url: "https://linkedin.com/in/rizafahmi" },
+      { label: "X", url: "https://x.com/rizafahmi22" },
+      { label: "YouTube", url: "https://youtube.com/rizafahmi" },
+    ],
+  },
+
+  /** Ringkasan pembuka. Satu entri = satu paragraf. */
+  summary: [
+    {
+      id: "Co-Founder Hacktiv8, coding bootcamp yang saya rintis sejak 2016 untuk menjawab kelangkaan developer yang menghambat tumbuhnya startup teknologi di Indonesia. Programnya imersif, 12 minggu, dan dirancang supaya orang dengan latar belakang teknis seadanya bisa sampai ke level junior developer yang layak dibayar.",
+      en: "I co-founded Hacktiv8 in 2016 to close the developer hiring gap that was holding back Indonesia's tech startups. It runs a 12-week immersive curriculum built so that people with little or no technical background can reach a paid junior developer role.",
+    },
+    {
+      id: "Sebelum itu saya menulis kode sejak 2003 dan naik pelan-pelan dari programmer ke team leader, head of R&D, sampai CTO — di portal berita, pendidikan online, dan civic tech. Sebagian besar pekerjaannya back-end, plus infrastruktur dan memimpin tim kecil.",
+      en: "Before that I had been shipping software since 2003, moving from programmer to team leader, head of R&D, and CTO across news portals, online education, and civic technology. Mostly back-end work, plus infrastructure and leading small teams.",
+    },
+    {
+      id: "Bagian yang paling saya nikmati adalah membagikan ulang apa yang saya pelajari: bikin konten pemrograman sejak 2012, ngobrol di podcast sejak 2015, dan ikut mengurus komunitas sejak 2014. Sekarang saya Google Developer Expert dan AWS Community Builder, dan sebagian besar tulisan serta eksperimen saya berkutat di Elixir dan AI untuk ngoding.",
+      en: "The part I enjoy most is handing back what I learn: programming content since 2012, podcasting since 2015, and community organising since 2014. I am a Google Developer Expert and an AWS Community Builder, and most of my current writing and side projects sit where Elixir meets AI-assisted development.",
+    },
+  ],
+
+  /**
+   * Keahlian saat ini, bukan hasil endorsement LinkedIn. Isinya diambil dari
+   * bukti yang ada: tag di src/_data/karya.js, halaman topik, dan tulisan terbaru.
+   */
+  skills: [
+    {
+      group: { id: "Bahasa & runtime", en: "Languages & runtimes" },
+      items: ["Elixir", "JavaScript", "TypeScript", "Node.js", "Bash"],
+    },
+    {
+      group: { id: "Framework & tooling", en: "Frameworks & tooling" },
+      items: ["Phoenix LiveView", "OTP", "Astro", "Eleventy"],
+    },
+    {
+      group: { id: "Data & infrastruktur", en: "Data & infrastructure" },
+      items: ["SQLite", "Turso", "Local-first", "Linux"],
+    },
+    {
+      group: { id: "AI & agentic coding", en: "AI & agentic coding" },
+      items: ["Anthropic API", "Gemini API", "Agentic coding", "LLM evaluation"],
+    },
+    {
+      group: { id: "Cara kerja", en: "Ways of working" },
+      items: [
+        { id: "Memimpin tim engineering", en: "Engineering leadership" },
+        { id: "Perancangan kurikulum", en: "Curriculum design" },
+        { id: "Menulis teknis", en: "Technical writing" },
+        { id: "Berbicara di publik & workshop", en: "Public speaking & workshops" },
+      ],
+    },
+  ],
+
+  /**
+   * Riwayat kerja, terbaru di atas. Satu perusahaan = satu blok, walaupun
+   * jabatannya berganti (lihat Hacktiv8) — `roles` diisi dari yang terbaru.
+   */
+  experience: [
+    {
+      org: "Hacktiv8 Indonesia",
+      url: "https://hacktiv8.com",
+      roles: [
+        { title: { id: "Co-Founder", en: "Co-Founder" }, start: "2018-11", end: null },
+        {
+          title: { id: "Curriculum Director, Co-Founder", en: "Curriculum Director, Co-Founder" },
+          start: "2016-03",
+          end: "2018-11",
+        },
+      ],
+      summary: {
+        id: "Coding bootcamp yang mengubah pemula jadi full-stack web developer dalam 12 minggu, termasuk mereka yang nyaris tanpa latar belakang teknis, sampai layak masuk posisi junior developer berbayar.",
+        en: "A web development bootcamp that turns beginners into full-stack web developers in 12 weeks — including people with little or no technical background — up to the level of a paid junior developer role.",
+      },
+      highlights: [
+        {
+          id: "Menyusun dan menjalankan kurikulum imersif 12 minggu, dari nol sampai siap kerja.",
+          en: "Built and ran the 12-week immersive curriculum, from zero to job-ready.",
+        },
+        {
+          id: "Menjaga tiga kesepakatan yang jadi budaya kerja: integritas, kebaikan, dan datang sebagai diri sendiri seutuhnya.",
+          en: "Held the three agreements the company runs on: integrity, kindness, and bringing your whole self.",
+        },
+      ],
+    },
+    {
+      org: "CitizenLab",
+      roles: [
+        {
+          title: { id: "Chief Technology Officer", en: "Chief Technology Officer" },
+          start: "2015-08",
+          end: "2016-02",
+        },
+      ],
+      summary: {
+        id: "SaaS civic engagement: warga ikut merancang kotanya sendiri — mengusulkan ide, memberi dukungan, dan pemerintah daerah menjalankan crowdvoting, misalnya untuk alokasi anggaran.",
+        en: "A civic engagement SaaS where citizens co-create their city — posting and upvoting ideas — and governments run crowdvoting exercises such as budget allocation.",
+      },
+      highlights: [
+        {
+          id: "Memegang hampir seluruh sisi teknis: back-end sebagai porsi terbesar, sebagian front-end, pemeliharaan, dan infrastruktur.",
+          en: "Owned essentially all technical aspects: mostly back-end, some front-end, maintenance, and infrastructure.",
+        },
+      ],
+    },
+    {
+      org: "PT Haruka Edukasi Utama (HarukaEdu)",
+      roles: [{ title: { id: "Developer", en: "Developer" }, start: "2013-07", end: "2015-09" }],
+      summary: {
+        id: "Platform pendidikan online untuk perguruan tinggi.",
+        en: "An online education platform for higher education institutions.",
+      },
+      highlights: [
+        {
+          id: "Merencanakan pengembangan, mengelola proyek dan tim developer.",
+          en: "Development planning, managing the project and the developer team.",
+        },
+        {
+          id: "Membangun dan merawat platform, plus riset dan pengembangan untuk perbaikannya.",
+          en: "Building and maintaining the platform, plus R&D for platform improvements.",
+        },
+      ],
+    },
+    {
+      // Satu pekerjaan dengan dua nama. LinkedIn memecahnya jadi dua entri
+      // dengan rentang tanggal yang persis sama; jangan dihitung dua kali.
+      org: "PT. IONSOFT / IYAA.com (PT Indoportal Nusantara)",
+      roles: [
+        { title: { id: "Head of R&D", en: "Head of R&D" }, start: "2012-02", end: "2013-07" },
+      ],
+      summary: {
+        id: "Portal media dan layanan digital IYAA.com.",
+        en: "The IYAA.com media portal and its digital services.",
+      },
+      highlights: [
+        {
+          id: "Memimpin tim riset dan pengembangan.",
+          en: "Managing the research and development team.",
+        },
+      ],
+    },
+    {
+      org: "PT. Okezone Indonesia",
+      roles: [
+        {
+          title: { id: "Team Leader Programmer", en: "Team Leader Programmer" },
+          start: "2011",
+          end: "2012",
+        },
+      ],
+      summary: {
+        id: "Memimpin dan mengembangkan portal berita serta aplikasi internal menggunakan PHP, XML, MySQL, dan Django/Python.",
+        en: "Led and developed news portals and internal applications using PHP, XML, MySQL, and Django/Python.",
+      },
+      highlights: [
+        { id: "Mendesain ulang kanal-kanal portal.", en: "Redesigned the portal canals." },
+        { id: "Mengembangkan www.sindonews.com.", en: "Developed www.sindonews.com." },
+        {
+          id: "Membangun versi mobile sindonews dengan Django/Python.",
+          en: "Built the sindonews mobile version in Django/Python.",
+        },
+      ],
+    },
+    {
+      org: "Linuxindo",
+      roles: [{ title: { id: "Programmer", en: "Programmer" }, start: "2007", end: "2011" }],
+      summary: {
+        id: "Mengembangkan dan menganalisis aplikasi web di berbagai framework PHP dan basis data.",
+        en: "Developed and analysed web applications across various PHP frameworks and databases.",
+      },
+      highlights: [
+        { id: "Sistem ERP berbasis web.", en: "A web-based ERP system." },
+        { id: "Sistem MLM yang dirancang dengan UML.", en: "An MLM system designed with UML." },
+        { id: "Sistem pelaporan fax server.", en: "A fax server reporting system." },
+        { id: "Mengajar PostgreSQL.", en: "Lectured PostgreSQL." },
+      ],
+    },
+    {
+      org: "PT. Ainetworks Indonesia",
+      roles: [{ title: { id: "Programmer", en: "Programmer" }, start: "2003", end: "2007-05" }],
+      summary: {
+        id: "Aplikasi web, sebagian besar dengan PHP dan PostgreSQL.",
+        en: "Web applications, mainly in PHP and PostgreSQL.",
+      },
+      highlights: [
+        { id: "Sistem administrasi sekolah.", en: "A school administration system." },
+        { id: "Sistem SMS broadcast.", en: "An SMS broadcast system." },
+        { id: "Sistem absensi.", en: "An attendance system." },
+        { id: "Sistem delivery order.", en: "A delivery order system." },
+        { id: "Sistem informasi rumah sakit.", en: "A hospital information system." },
+        { id: "Sistem informasi perbankan.", en: "A banking information system." },
+      ],
+    },
+  ],
+
+  education: [
+    {
+      school: "University of Indonesia",
+      degree: {
+        id: "Magister (S2), Teknologi Informasi",
+        en: "Master's degree, Information Technology",
+      },
+      start: "2008",
+      end: "2010",
+    },
+    {
+      school: "BINUS University",
+      degree: {
+        id: "Sarjana (S1), Teknologi Informasi",
+        en: "Bachelor's degree, Information Technology",
+      },
+      start: "1999",
+      end: "2003",
+    },
+  ],
+
+  /** Mengajar, komunitas, dan peran yang bukan pekerjaan penuh waktu. */
+  teaching: [
+    {
+      id: "Dosen di Universitas Budi Luhur.",
+      en: "Lecturer at Universitas Budi Luhur.",
+    },
+    {
+      id: "Google Developer Expert (GDE) dan AWS Community Builder.",
+      en: "Google Developer Expert (GDE) and AWS Community Builder.",
+    },
+    {
+      id: "Organizer JakartaJS dan Meteor Jakarta.",
+      en: "Organiser of JakartaJS and Meteor Jakarta.",
+    },
+    {
+      id: "Merawat Awesome Speakers Indonesia, daftar terbuka developer yang berkenan diundang jadi narasumber.",
+      en: "Maintains Awesome Speakers Indonesia, an open directory of developers happy to be invited to speak.",
+    },
+  ],
+
+  speaking: {
+    /** Angka diambil dari halaman /kerjasama/ (src/ratecard.njk). */
+    tally: [
+      { count: 41, label: { id: "acara seminar", en: "talks and seminars" } },
+      { count: 19, label: { id: "workshop", en: "workshops" } },
+    ],
+    topics: {
+      id: "Pengembangan perangkat lunak, komputasi awan, arsitektur, basis data, soft skill, dan topik teknologi lain.",
+      en: "Software development, cloud computing, architecture, databases, soft skills, and other technology topics.",
+    },
+    /** Panggung yang benar-benar tercatat — jangan menambah yang tidak ada buktinya. */
+    stages: [
+      "JSDay Indonesia 2019 (keynote)",
+      "DevFest GDG Jogja 2025 (workshop)",
+      "Singapore Elixir Meetup",
+      "GeekCamp",
+      "Lambda Jakarta",
+    ],
+    collaborations: [
+      "AWS Indonesia",
+      "BenQ Indonesia",
+      "Meta/Facebook",
+      "Google Indonesia",
+      "Domainesia",
+      "Niagahoster",
+      "Feedloop",
+      "DeepTech",
+    ],
+  },
+
+  content: {
+    since: [
+      {
+        id: "Membuat konten pemrograman sejak 2012",
+        en: "Creating programming content since 2012",
+      },
+      { id: "Memandu podcast sejak 2015", en: "Hosting podcasts since 2015" },
+      {
+        id: "Berkontribusi ke komunitas pemrograman sejak 2014",
+        en: "Contributing to programming communities since 2014",
+      },
+    ],
+    channels: [
+      {
+        name: "Ngobrolin Web",
+        url: "https://ngobrol.in",
+        note: {
+          id: "Podcast mingguan yang membahas segala hal tentang web.",
+          en: "A weekly podcast about everything web.",
+        },
+      },
+      {
+        name: "YouTube",
+        url: "https://youtube.com/rizafahmi",
+        note: {
+          id: "Tutorial dan sesi livestream ngoding bareng seputar AI, Elixir, dan web.",
+          en: "Tutorials and live coding streams on AI, Elixir, and the web.",
+        },
+      },
+      {
+        name: "Ceritanya Developer",
+        url: "https://open.spotify.com/show/6grT1c7jDkhK4skm1YIsTs",
+        note: { id: "Podcast.", en: "Podcast." },
+      },
+      {
+        name: "Hikayat Punggawa Teknologi",
+        url: "https://www.youtube.com/playlist?list=PLTY2nW4jwtG9IEUCDspLH0tAuF450DZz-",
+        note: { id: "Serial podcast.", en: "Podcast series." },
+      },
+      {
+        name: "AppsCoast",
+        url: "https://open.spotify.com/show/6wjIRrIQ8yvAgCwXCUXKXI",
+        note: {
+          id: "Podcast tentang startup teknologi Indonesia.",
+          en: "A podcast about Indonesian tech startups.",
+        },
+      },
+    ],
+    courses: [
+      {
+        name: "SvelteJS",
+        url: "https://buildwithangga.com/kelas/sveltejs-front-end-javascript-development-web-donasi-online",
+        note: {
+          id: "Membangun aplikasi web donasi online dan integrasi payment gateway.",
+          en: "Building an online donation web app and integrating a payment gateway.",
+        },
+      },
+      {
+        name: {
+          id: "Struktur Data dengan JavaScript",
+          en: "Data Structures with JavaScript",
+        },
+        url: "https://buildwithangga.com/kelas/struktur-data-javascript-improve-website-e-commerce",
+        note: {
+          id: "Fundamental struktur data lewat JavaScript.",
+          en: "Data structure fundamentals through JavaScript.",
+        },
+      },
+      {
+        name: { id: "PWA dengan React", en: "PWA with React" },
+        url: "https://buildwithangga.com/kelas/mastering-react-js-progressive-web-apps-e-commerce",
+        note: {
+          id: "Menerapkan progressive web app dengan React.",
+          en: "Implementing progressive web apps with React.",
+        },
+      },
+    ],
+  },
+
+  /**
+   * Proyek di luar 13 karya open source yang sudah diambil dari karya.js.
+   */
+  projectsExtra: [
+    {
+      name: "Carikerja",
+      url: "https://carikerja.deeptech.id/",
+      note: {
+        id: "Daftar developer yang terdampak COVID-19, supaya lebih mudah ditemukan perusahaan.",
+        en: "A directory of developers affected by COVID-19, built so companies could find them.",
+      },
+    },
+    {
+      name: "Awesome Speakers Indonesia",
+      url: "https://github.com/rizafahmi/awesome-speakers-id",
+      note: {
+        id: "Daftar terbuka developer Indonesia yang berkenan jadi narasumber.",
+        en: "An open directory of Indonesian developers available to speak.",
+      },
+    },
+  ],
+
+  honours: {
+    certifications: ["2023 Southeast Asia EdTech 50"],
+    awards: ["Most Inspiring Lead"],
+    /**
+     * Judul saja. Ekspor LinkedIn tidak menyertakan tautan maupun tanggal, dan
+     * menebak URL untuk sebuah CV lebih buruk daripada tidak menautkan apa pun.
+     */
+    publications: [
+      "Reactive Programming Made Simple",
+      "How I Met 10 Entrepreneurs In Asia And What Can We Learn From Them",
+      "Startup Talks In Asia: Candid Interview With 10 Asian Start-up Founders About Their Entrepreneurial Journey",
+      "Meteor Introduction at TokoPedia Tech A Break #4",
+    ],
+  },
+
+  spokenLanguages: [
+    {
+      name: { id: "Bahasa Indonesia", en: "Indonesian" },
+      level: { id: "Penutur asli / dwibahasa", en: "Native or bilingual" },
+    },
+    {
+      name: { id: "Bahasa Inggris", en: "English" },
+      level: { id: "Kemampuan kerja profesional", en: "Professional working" },
+    },
+  ],
+};

--- a/src/_data/cv.js
+++ b/src/_data/cv.js
@@ -34,6 +34,14 @@
  * DAFTAR PROYEK
  *   13 proyek open source di halaman CV diambil langsung dari src/_data/karya.js,
  *   tidak disalin ke sini. Tambah proyek di sana, CV ikut terisi.
+ *
+ * STATUS KANAL
+ *   Tiap entri di `content.channels` wajib punya `status`: "current" atau
+ *   "retired". Label yang tampil (Berjalan/Running, Arsip/Archive) hidup di
+ *   template, bukan di sini — jadi membalik status satu kanal cukup mengganti
+ *   satu kata di file ini. Halaman menampilkan yang masih berjalan dulu,
+ *   lalu yang sudah diarsip, dengan urutan relatif di dalam tiap kelompok
+ *   tetap seperti di sini.
  */
 
 export default {
@@ -247,7 +255,7 @@ export default {
         en: "Led and developed news portals and internal applications using PHP, XML, MySQL, and Django/Python.",
       },
       highlights: [
-        { id: "Mendesain ulang kanal-kanal portal.", en: "Redesigned the portal canals." },
+        { id: "Mendesain ulang kanal-kanal portal.", en: "Redesigned the portal channels." },
         { id: "Mengembangkan www.sindonews.com.", en: "Developed www.sindonews.com." },
         {
           id: "Membangun versi mobile sindonews dengan Django/Python.",
@@ -374,6 +382,7 @@ export default {
       {
         name: "Ngobrolin Web",
         url: "https://ngobrol.in",
+        status: "current",
         note: {
           id: "Podcast mingguan yang membahas segala hal tentang web.",
           en: "A weekly podcast about everything web.",
@@ -382,6 +391,7 @@ export default {
       {
         name: "YouTube",
         url: "https://youtube.com/rizafahmi",
+        status: "current",
         note: {
           id: "Tutorial dan sesi livestream ngoding bareng seputar AI, Elixir, dan web.",
           en: "Tutorials and live coding streams on AI, Elixir, and the web.",
@@ -390,16 +400,19 @@ export default {
       {
         name: "Ceritanya Developer",
         url: "https://open.spotify.com/show/6grT1c7jDkhK4skm1YIsTs",
+        status: "retired",
         note: { id: "Podcast.", en: "Podcast." },
       },
       {
         name: "Hikayat Punggawa Teknologi",
         url: "https://www.youtube.com/playlist?list=PLTY2nW4jwtG9IEUCDspLH0tAuF450DZz-",
+        status: "retired",
         note: { id: "Serial podcast.", en: "Podcast series." },
       },
       {
         name: "AppsCoast",
         url: "https://open.spotify.com/show/6wjIRrIQ8yvAgCwXCUXKXI",
+        status: "retired",
         note: {
           id: "Podcast tentang startup teknologi Indonesia.",
           en: "A podcast about Indonesian tech startups.",

--- a/src/_data/cv.js
+++ b/src/_data/cv.js
@@ -32,7 +32,7 @@
  *   memajang tautan mati lebih buruk daripada CV tanpa tautan sama sekali.
  *
  * DAFTAR PROYEK
- *   13 proyek open source di halaman CV diambil langsung dari src/_data/karya.js,
+ *   Proyek open source di halaman CV diambil langsung dari src/_data/karya.js,
  *   tidak disalin ke sini. Tambah proyek di sana, CV ikut terisi.
  *
  * STATUS KANAL
@@ -451,7 +451,7 @@ export default {
   },
 
   /**
-   * Proyek di luar 13 karya open source yang sudah diambil dari karya.js.
+   * Proyek di luar daftar open source yang sudah diambil dari karya.js.
    */
   projectsExtra: [
     {

--- a/src/_includes/cv.njk
+++ b/src/_includes/cv.njk
@@ -1,0 +1,64 @@
+{#
+  Layout khusus halaman CV (/cv/ dan /cv/en/).
+
+  Kenapa tidak numpang main.njk: halaman ini butuh dua hal yang tidak dipunyai
+  layout lain — atribut lang yang mengikuti bahasa halaman (main.njk, tulisan.njk,
+  dan serial.njk semuanya menulis lang="id" secara tetap, dan itu benar untuk
+  mereka), plus stylesheet cetaknya sendiri. Dengan layout terpisah, halaman
+  Indonesia yang sudah ada tidak tersentuh sama sekali.
+
+  Chrome situs (header, tombol tema, tombol cetak, pengalih bahasa) sengaja
+  dipisah dari isi CV: semuanya hilang saat dicetak lewat assets/cv.css.
+#}
+<!DOCTYPE html>
+<html lang="{{ pageLang or 'id' }}">
+  <head>
+    {# Judul ini juga jadi nama berkas PDF ketika halaman dicetak dari browser. #}
+    <title>{{ title }}</title>
+    <link rel="preload" as="style" href="/assets/global.css?v={{ site.buildTime }}" type="text/css" />
+    <link rel="stylesheet" href="/assets/global.css?v={{ site.buildTime }}" type="text/css" />
+    <link rel="preload" as="style" href="/assets/cv.css?v={{ site.buildTime }}" type="text/css" />
+    <link rel="stylesheet" href="/assets/cv.css?v={{ site.buildTime }}" type="text/css" />
+    {% include 'head.njk' %}
+  </head>
+  <body class="cv-page">
+    {%- set meta = cv.meta[pageLang] -%}
+    {%- set otherMeta = cv.meta["en" if pageLang == "id" else "id"] -%}
+    {# Chrome situs ditulis dalam bahasa Indonesia apa pun bahasa halamannya,
+       jadi ditandai lang="id" supaya pembaca layar tidak salah melafalkan. #}
+    <a href="#main-content" class="skip-link" lang="id">Langsung ke konten utama</a>
+    <header class="site-header" lang="id" style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+      <div style="display:flex; align-items:center; gap: 0.75rem;">
+        <h1 style="margin:0;"><a href="/">👋 Saya Riza!</a></h1>
+        <nav class="hero-nav" style="margin-left: .25rem;">
+          <a href="/articles">Catatan</a>
+          <a href="/tags">Topik</a>
+          <a href="/search">Cari</a>
+        </nav>
+      </div>
+      <button id="theme-toggle" class="theme-toggle" aria-label="Toggle Dark Mode">🌙</button>
+    </header>
+
+    <main id="main-content" class="cv-main"{% if pageLang != 'en' %} data-pagefind-body data-pagefind-meta="title:{{ meta.title }}"{% else %} data-pagefind-ignore{% endif %}>
+      <div class="cv-toolbar" role="group" aria-label="{{ meta.ui.toolbar }}">
+        <button type="button" class="cv-button" data-cv-print>{{ meta.ui.print }}</button>
+        <a class="cv-button" href="{{ otherMeta.permalink }}" hreflang="{{ otherMeta.htmlLang }}" lang="{{ otherMeta.htmlLang }}">{{ otherMeta.languageName }}</a>
+      </div>
+
+      {{ content | safe }}
+
+      <a class="back" href="/">&lt; {{ meta.ui.back }}</a>
+    </main>
+
+    <script>
+      (function () {
+        var button = document.querySelector('[data-cv-print]');
+        if (button) button.addEventListener('click', function () { window.print(); });
+      })();
+    </script>
+    {% include 'analytics.njk' %}
+    {% include 'webvitals.njk' %}
+    {% include 'keyboard-shortcuts.njk' %}
+    {% include 'theme-toggle.njk' %}
+  </body>
+</html>

--- a/src/_includes/cv_body.njk
+++ b/src/_includes/cv_body.njk
@@ -37,7 +37,11 @@
   certifications: { id: "Sertifikasi", en: "Certifications" },
   awards: { id: "Penghargaan", en: "Honours" },
   publications: { id: "Publikasi", en: "Publications" },
-  updated: { id: "Diperbarui", en: "Updated" }
+  updated: { id: "Diperbarui", en: "Updated" },
+  channelStatus: {
+    current: { id: "Berjalan", en: "Running" },
+    retired: { id: "Arsip", en: "Archive" }
+  }
 } %}
 
 {% macro render(cv, lang, projects) %}
@@ -154,9 +158,10 @@
 
     <h3 class="cv-subhead">{{ L.channels | translate(lang) }}</h3>
     <ul class="cv-list">
-      {%- for channel in cv.content.channels %}
+      {%- for channel in cv.content.channels | orderedChannels %}
       <li>
         <a href="{{ channel.url }}" rel="noopener">{{ channel.name | translate(lang) }}</a>
+        <span class="cv-status">{{ L.channelStatus[channel.status] | translate(lang) }}</span>
         — {{ channel.note | translate(lang) }}
       </li>
       {%- endfor %}

--- a/src/_includes/cv_body.njk
+++ b/src/_includes/cv_body.njk
@@ -1,0 +1,234 @@
+{#
+  Isi halaman CV. Dipakai dua kali — /cv/ dan /cv/en/ — dengan data yang sama
+  dari src/_data/cv.js, jadi kedua bahasa tidak mungkin melenceng strukturnya.
+
+  Judul bagian ditulis di `L` di bawah karena itu teks antarmuka, bukan isi CV;
+  isi CV-nya diedit di src/_data/cv.js.
+
+  Yang perlu dijaga saat mengedit:
+    - setiap <section> punya id yang sama di kedua bahasa (dipakai untuk
+      pengecekan kesejajaran di test/cv-page.test.js dan untuk tautan jangkar);
+    - satu entri pengalaman = satu .cv-entry, supaya CSS cetak bisa menjaga
+      entrinya tidak terbelah antar halaman;
+    - teks tautan profil sengaja berupa alamatnya sendiri (tanpa "https://"),
+      bukan kata seperti "GitHub". Di kertas tautan tidak bisa diklik, jadi
+      alamatnya harus ikut terbaca. Tautan lain di halaman ini tetap memakai
+      nama biasa: satu CV yang penuh URL panjang lebih buruk daripada tanpa URL.
+#}
+
+{% set L = {
+  summary: { id: "Ringkasan", en: "Summary" },
+  skills: { id: "Keahlian", en: "Skills" },
+  experience: { id: "Pengalaman Kerja", en: "Work Experience" },
+  education: { id: "Pendidikan", en: "Education" },
+  teaching: { id: "Mengajar & Komunitas", en: "Teaching & Community" },
+  speaking: { id: "Berbicara & Workshop", en: "Speaking & Workshops" },
+  content: { id: "Konten & Podcast", en: "Content & Podcasting" },
+  projects: { id: "Karya Terpilih", en: "Selected Work" },
+  honours: { id: "Penghargaan & Publikasi", en: "Honours & Publications" },
+  languages: { id: "Bahasa", en: "Languages" },
+  email: { id: "Email", en: "Email" },
+  openSource: { id: "Open source", en: "Open source" },
+  otherWork: { id: "Lainnya", en: "Other work" },
+  channels: { id: "Kanal", en: "Channels" },
+  courses: { id: "Kursus", en: "Courses" },
+  stages: { id: "Panggung terpilih", en: "Selected stages" },
+  collaborations: { id: "Pernah berkolaborasi dengan", en: "Collaborated with" },
+  certifications: { id: "Sertifikasi", en: "Certifications" },
+  awards: { id: "Penghargaan", en: "Honours" },
+  publications: { id: "Publikasi", en: "Publications" },
+  updated: { id: "Diperbarui", en: "Updated" }
+} %}
+
+{% macro render(cv, lang, projects) %}
+<article class="cv">
+
+  <header class="cv-header">
+    <h1 class="cv-name">{{ cv.identity.name }}</h1>
+    <p class="cv-headline">{{ cv.identity.headline | translate(lang) }}</p>
+    <ul class="cv-contact">
+      <li>
+        <span class="cv-contact-label">{{ L.email | translate(lang) }}</span>
+        <a href="mailto:{{ cv.identity.email }}">{{ cv.identity.email }}</a>
+      </li>
+      {%- for profile in cv.identity.profiles %}
+      <li>
+        <span class="cv-contact-label">{{ profile.label | translate(lang) }}</span>
+        <a class="print-url" href="{{ profile.url }}" rel="me noopener">{{ profile.url | replace("https://", "") }}</a>
+      </li>
+      {%- endfor %}
+    </ul>
+  </header>
+
+  <section id="summary" class="cv-section">
+    <h2>{{ L.summary | translate(lang) }}</h2>
+    {%- for paragraph in cv.summary %}
+    <p>{{ paragraph | translate(lang) }}</p>
+    {%- endfor %}
+  </section>
+
+  <section id="skills" class="cv-section">
+    <h2>{{ L.skills | translate(lang) }}</h2>
+    <dl class="cv-skills">
+      {%- for group in cv.skills %}
+      <div class="cv-skill-group">
+        <dt>{{ group.group | translate(lang) }}</dt>
+        <dd>
+          {%- for item in group.items %}{{ item | translate(lang) }}{% if not loop.last %} · {% endif %}{% endfor -%}
+        </dd>
+      </div>
+      {%- endfor %}
+    </dl>
+  </section>
+
+  <section id="experience" class="cv-section">
+    <h2>{{ L.experience | translate(lang) }}</h2>
+    {%- for entry in cv.experience %}
+    <div class="cv-entry">
+      <h3 class="cv-org">
+        {%- if entry.url %}<a href="{{ entry.url }}" rel="noopener">{{ entry.org }}</a>{% else %}{{ entry.org }}{% endif -%}
+      </h3>
+      {%- for role in entry.roles %}
+      <p class="cv-role">
+        <span class="cv-role-title">{{ role.title | translate(lang) }}</span>
+        <span class="cv-period">{{ role | cvPeriod(lang) }}</span>
+      </p>
+      {%- endfor %}
+      <p class="cv-summary">{{ entry.summary | translate(lang) }}</p>
+      {%- if entry.highlights.length %}
+      <ul class="cv-highlights">
+        {%- for highlight in entry.highlights %}
+        <li>{{ highlight | translate(lang) }}</li>
+        {%- endfor %}
+      </ul>
+      {%- endif %}
+    </div>
+    {%- endfor %}
+  </section>
+
+  <section id="education" class="cv-section">
+    <h2>{{ L.education | translate(lang) }}</h2>
+    {%- for item in cv.education %}
+    <div class="cv-entry">
+      <h3 class="cv-org">{{ item.school }}</h3>
+      <p class="cv-role">
+        <span class="cv-role-title">{{ item.degree | translate(lang) }}</span>
+        <span class="cv-period">{{ item | cvPeriod(lang) }}</span>
+      </p>
+    </div>
+    {%- endfor %}
+  </section>
+
+  <section id="teaching" class="cv-section">
+    <h2>{{ L.teaching | translate(lang) }}</h2>
+    <ul class="cv-list">
+      {%- for item in cv.teaching %}
+      <li>{{ item | translate(lang) }}</li>
+      {%- endfor %}
+    </ul>
+  </section>
+
+  <section id="speaking" class="cv-section">
+    <h2>{{ L.speaking | translate(lang) }}</h2>
+    <p class="cv-tally">
+      {%- for item in cv.speaking.tally %}<strong>{{ item.count }}</strong> {{ item.label | translate(lang) }}{% if not loop.last %} · {% endif %}{% endfor -%}
+    </p>
+    <p>{{ cv.speaking.topics | translate(lang) }}</p>
+    <p class="cv-inline">
+      <span class="cv-inline-label">{{ L.stages | translate(lang) }}</span>
+      {{ cv.speaking.stages | join(" · ") }}
+    </p>
+    <p class="cv-inline">
+      <span class="cv-inline-label">{{ L.collaborations | translate(lang) }}</span>
+      {{ cv.speaking.collaborations | join(" · ") }}
+    </p>
+  </section>
+
+  <section id="content" class="cv-section">
+    <h2>{{ L.content | translate(lang) }}</h2>
+    <ul class="cv-list">
+      {%- for item in cv.content.since %}
+      <li>{{ item | translate(lang) }}</li>
+      {%- endfor %}
+    </ul>
+
+    <h3 class="cv-subhead">{{ L.channels | translate(lang) }}</h3>
+    <ul class="cv-list">
+      {%- for channel in cv.content.channels %}
+      <li>
+        <a href="{{ channel.url }}" rel="noopener">{{ channel.name | translate(lang) }}</a>
+        — {{ channel.note | translate(lang) }}
+      </li>
+      {%- endfor %}
+    </ul>
+
+    <h3 class="cv-subhead">{{ L.courses | translate(lang) }}</h3>
+    <ul class="cv-list">
+      {%- for course in cv.content.courses %}
+      <li>
+        <a href="{{ course.url }}" rel="noopener">{{ course.name | translate(lang) }}</a>
+        — {{ course.note | translate(lang) }}
+      </li>
+      {%- endfor %}
+    </ul>
+  </section>
+
+  <section id="projects" class="cv-section">
+    <h2>{{ L.projects | translate(lang) }}</h2>
+
+    <h3 class="cv-subhead">{{ L.openSource | translate(lang) }}</h3>
+    <ul class="cv-list cv-projects">
+      {%- for project in projects %}
+      <li class="cv-project">
+        <a href="{{ project.url or project.repo }}" rel="noopener">{{ project.name }}</a>
+        {%- if project.tags.length %}
+        <span class="cv-tags">{{ project.tags | join(" · ") }}</span>
+        {%- endif %}
+      </li>
+      {%- endfor %}
+    </ul>
+
+    <h3 class="cv-subhead">{{ L.otherWork | translate(lang) }}</h3>
+    <ul class="cv-list cv-projects-extra">
+      {%- for item in cv.projectsExtra %}
+      <li>
+        <a href="{{ item.url }}" rel="noopener">{{ item.name }}</a>
+        — {{ item.note | translate(lang) }}
+      </li>
+      {%- endfor %}
+    </ul>
+  </section>
+
+  <section id="honours" class="cv-section">
+    <h2>{{ L.honours | translate(lang) }}</h2>
+    <p class="cv-inline">
+      <span class="cv-inline-label">{{ L.certifications | translate(lang) }}</span>
+      {{ cv.honours.certifications | join(" · ") }}
+    </p>
+    <p class="cv-inline">
+      <span class="cv-inline-label">{{ L.awards | translate(lang) }}</span>
+      {{ cv.honours.awards | join(" · ") }}
+    </p>
+    <h3 class="cv-subhead">{{ L.publications | translate(lang) }}</h3>
+    <ul class="cv-list">
+      {%- for publication in cv.honours.publications %}
+      <li>{{ publication }}</li>
+      {%- endfor %}
+    </ul>
+  </section>
+
+  <section id="languages" class="cv-section">
+    <h2>{{ L.languages | translate(lang) }}</h2>
+    <dl class="cv-skills">
+      {%- for item in cv.spokenLanguages %}
+      <div class="cv-skill-group">
+        <dt>{{ item.name | translate(lang) }}</dt>
+        <dd>{{ item.level | translate(lang) }}</dd>
+      </div>
+      {%- endfor %}
+    </dl>
+  </section>
+
+  <p class="cv-updated">{{ L.updated | translate(lang) }} {{ cv.updated | cvMonth(lang) }}</p>
+</article>
+{% endmacro %}

--- a/src/_includes/head.njk
+++ b/src/_includes/head.njk
@@ -30,6 +30,9 @@
 {%- set _ogImageUrl = "https://rizafahmi.com" ~ _ogPath -%}
 
 <link rel="canonical" href="https://rizafahmi.com{{ page.url | escape }}" />
+{%- for alternate in (alternates or []) %}
+<link rel="alternate" hreflang="{{ alternate.hreflang }}" href="https://rizafahmi.com{{ alternate.href }}" />
+{%- endfor %}
 <meta name="description" content="{{ _desc | escape }}">
 {%- set _isExcludedArticle = tags and 'catatan' in tags and eleventyExcludeFromCollections -%}
 {%- if noindex or _isExcludedArticle %}
@@ -38,7 +41,7 @@
 <meta name="robots" content="index,follow,max-image-preview:large">
 {%- endif %}
 <meta property="og:site_name" content="{{ site.name | escape }}" />
-<meta property="og:locale" content="id_ID" />
+<meta property="og:locale" content="{{ pageLocale or 'id_ID' }}" />
 <meta property="og:title" content="{{ _ogTitle | escape }}" />
 <meta property="og:type" content="{{ _ogType }}" />
 <meta property="og:description" content="{{ _desc | escape }}" />
@@ -117,7 +120,7 @@
       "url": "{{ site.url }}{{ page.url }}",
       "name": {{ title | jsonify | safe }},
       "description": {{ _desc | jsonify | safe }},
-      "inLanguage": "id-ID",
+      "inLanguage": {{ (pageLangTag or "id-ID") | jsonify | safe }},
       "isPartOf": {
         "@id": "{{ site.url }}/#website"
       },

--- a/src/cv.njk
+++ b/src/cv.njk
@@ -1,0 +1,41 @@
+---
+# Halaman CV — SATU berkas ini menghasilkan DUA halaman:
+#
+#   /cv/     Bahasa Indonesia
+#   /cv/en/  Bahasa Inggris
+#
+# Isi CV-nya ada di src/_data/cv.js, tampilannya di src/_includes/cv_body.njk,
+# dan kerangka halamannya di src/_includes/cv.njk. Jadi tidak ada satu kalimat
+# pun yang ditulis dua kali — menambah bahasa cukup dengan menambahkannya di
+# `languages` dan `meta` pada src/_data/cv.js.
+#
+# `pagination` di bawah adalah cara bawaan Eleventy untuk membuat satu halaman
+# per item daftar: daftarnya `cv.languages` (["id", "en"]), diambil satu-satu,
+# dan tiap giliran tersedia sebagai variabel `lang`.
+pagination:
+  data: cv.languages
+  size: 1
+  alias: lang
+layout: cv
+eleventyExcludeFromCollections: true
+
+# Alamat dan metadata tiap versi diambil dari cv.meta[lang], bukan ditulis ulang.
+eleventyComputed:
+  permalink: "{{ cv.meta[lang].permalink }}"
+  title: "{{ cv.meta[lang].title }}"
+  description: "{{ cv.meta[lang].description }}"
+  pageLang: "{{ cv.meta[lang].htmlLang }}"
+  pageLocale: "{{ cv.meta[lang].ogLocale }}"
+  pageLangTag: "{{ cv.meta[lang].langTag }}"
+
+# Sama di kedua halaman: keduanya mengumumkan seluruh versi yang ada.
+alternates:
+  - hreflang: id
+    href: /cv/
+  - hreflang: en
+    href: /cv/en/
+  - hreflang: x-default
+    href: /cv/
+---
+{% import "cv_body.njk" as cvBody %}
+{{ cvBody.render(cv, lang, karya | karyaProjects) }}

--- a/src/index.njk
+++ b/src/index.njk
@@ -205,6 +205,7 @@ eleventyExcludeFromCollections: true
         <a href="mailto:rizafahmi@gmail.com" target="_blank" rel="noopener noreferrer">Email</a>
         <a href="/uses/">Uses</a>
         <a href="/now/">Now</a>
+        <a href="/cv/">CV</a>
       </div>
     </section>
   </main>

--- a/src/libs/cv.js
+++ b/src/libs/cv.js
@@ -1,0 +1,106 @@
+/**
+ * Helpers for the CV pages (/cv/ and /cv/en/).
+ *
+ * The content itself lives in src/_data/cv.js — this module only formats it.
+ * No fetching, no inferring: whatever the data file says, in the order it says.
+ *
+ * Two rules drive the shapes here:
+ *
+ *   1. Dates are stored as "YYYY" or "YYYY-MM" and formatted at build time.
+ *      The LinkedIn export's stated durations ("7 years 1 month") were computed
+ *      the day it was exported and are already wrong, so nothing here reads a
+ *      duration from the data. An open-ended role stores `end: null` and prints
+ *      "Sekarang" / "Present", which stays honest however long the page sits.
+ *
+ *   2. Prose is stored as { id, en } and picked per page. Both language pages
+ *      render from the same data, so neither can drift away from the other.
+ */
+
+const MONTHS = {
+  id: [
+    "Januari",
+    "Februari",
+    "Maret",
+    "April",
+    "Mei",
+    "Juni",
+    "Juli",
+    "Agustus",
+    "September",
+    "Oktober",
+    "November",
+    "Desember",
+  ],
+  en: [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+  ],
+};
+
+const PRESENT = { id: "Sekarang", en: "Present" };
+
+const DEFAULT_LANG = "id";
+
+function months(lang) {
+  return MONTHS[lang] ?? MONTHS[DEFAULT_LANG];
+}
+
+/**
+ * Pick one language out of a { id, en } pair. Plain strings (a technology name,
+ * a school) pass straight through, so the data file only spells out both
+ * languages where the two genuinely differ.
+ */
+export function translate(value, lang) {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value;
+  return value[lang] ?? value[DEFAULT_LANG] ?? "";
+}
+
+/**
+ * "2018-11" -> "November 2018". A year-only date stays a bare year: the export
+ * only records year precision for the oldest roles, and inventing a month there
+ * would be inventing a fact.
+ */
+export function formatMonth(value, lang) {
+  if (typeof value !== "string") return "";
+  const trimmed = value.trim();
+  const match = trimmed.match(/^(\d{4})(?:-(\d{2}))?$/);
+  if (!match) return trimmed;
+
+  const [, year, month] = match;
+  if (!month) return year;
+
+  const index = Number(month) - 1;
+  const name = months(lang)[index];
+  return name ? `${name} ${year}` : year;
+}
+
+/** "Maret 2016 – November 2018", or "November 2018 – Sekarang" when open-ended. */
+export function formatPeriod(role, lang) {
+  const start = formatMonth(role?.start, lang);
+  const end = role?.end ? formatMonth(role.end, lang) : (PRESENT[lang] ?? PRESENT[DEFAULT_LANG]);
+  if (!start) return end;
+  return `${start} – ${end}`;
+}
+
+/**
+ * Every skill across every group, flattened into plain strings — handy for
+ * checks and indexes. Items are usually plain strings already (a technology
+ * name reads the same in both languages); the bilingual ones get picked here.
+ */
+export function skillItems(cv, lang = DEFAULT_LANG) {
+  if (!Array.isArray(cv?.skills)) return [];
+  return cv.skills
+    .flatMap((group) => (Array.isArray(group.items) ? group.items : []))
+    .map((item) => translate(item, lang));
+}

--- a/src/libs/cv.js
+++ b/src/libs/cv.js
@@ -104,3 +104,19 @@ export function skillItems(cv, lang = DEFAULT_LANG) {
     .flatMap((group) => (Array.isArray(group.items) ? group.items : []))
     .map((item) => translate(item, lang));
 }
+
+/**
+ * Content channels with current shows first, then retired, keeping the relative
+ * order inside each group. Flipping a channel's status in the data file is
+ * enough — this helper reorders at render time.
+ */
+export function orderedChannels(channels) {
+  if (!Array.isArray(channels)) return [];
+  const current = [];
+  const retired = [];
+  for (const channel of channels) {
+    if (channel?.status === "current") current.push(channel);
+    else if (channel?.status === "retired") retired.push(channel);
+  }
+  return [...current, ...retired];
+}

--- a/src/libs/karya.js
+++ b/src/libs/karya.js
@@ -1,5 +1,5 @@
 /**
- * Helpers for curated open source projects (showcase cards and LLM indexes).
+ * Helpers for curated open source projects (showcase, CV, and LLM indexes).
  *
  * The content itself is hand-curated in src/_data/karya.js — this module only
  * cleans the entries up. No fetching and no inferring: whatever the data file

--- a/src/llms.njk
+++ b/src/llms.njk
@@ -18,6 +18,8 @@ This file is a concise, machine-readable map for LLMs, answer engines, and AI as
 - [Web topic hub](https://rizafahmi.com/topik/web/): Writing about web development and JavaScript.
 - [Uses](https://rizafahmi.com/uses/): Tools, hardware, and software setup.
 - [Now](https://rizafahmi.com/now/): Current focus and projects.
+- [CV, Indonesian](https://rizafahmi.com/cv/): Work history, education, speaking, and public work. Print-ready.
+- [CV, English](https://rizafahmi.com/cv/en/): The same CV in English.
 - [AI usage disclosure](https://rizafahmi.com/ai/): How AI is used in the writing and coding process.
 
 ## Machine-readable indexes

--- a/src/sitemap.njk
+++ b/src/sitemap.njk
@@ -15,6 +15,8 @@ eleventyExcludeFromCollections: true
     "/topik/web/",
     "/topik/produktivitas/",
     "/showcase/",
+    "/cv/",
+    "/cv/en/",
     "/now/",
     "/uses/",
     "/ai/"

--- a/test/cv-page.test.js
+++ b/test/cv-page.test.js
@@ -4,7 +4,7 @@ import test from "node:test";
 import nunjucks from "nunjucks";
 import cv from "../src/_data/cv.js";
 import karya from "../src/_data/karya.js";
-import { formatMonth, formatPeriod, translate } from "../src/libs/cv.js";
+import { formatMonth, formatPeriod, orderedChannels, translate } from "../src/libs/cv.js";
 import { selectProjects } from "../src/libs/karya.js";
 
 const env = new nunjucks.Environment(new nunjucks.FileSystemLoader("src/_includes"), {
@@ -13,6 +13,7 @@ const env = new nunjucks.Environment(new nunjucks.FileSystemLoader("src/_include
 env.addFilter("translate", translate);
 env.addFilter("cvPeriod", formatPeriod);
 env.addFilter("cvMonth", formatMonth);
+env.addFilter("orderedChannels", orderedChannels);
 
 function render(lang) {
   return env.renderString(
@@ -99,4 +100,40 @@ test("profile links read as their own address, so they survive being printed", (
       );
     }
   }
+});
+
+test("both languages render a visible status for every content channel", () => {
+  const channelCount = cv.content.channels.length;
+  for (const [lang, html] of Object.entries(pages)) {
+    assert.equal(
+      count(html, /class="cv-status"/g),
+      channelCount,
+      `${lang} must show a status badge for every channel`,
+    );
+  }
+  assert.match(pages.id, /Berjalan/);
+  assert.match(pages.id, /Arsip/);
+  assert.match(pages.en, /Running/);
+  assert.match(pages.en, /Archive/);
+  assert.doesNotMatch(pages.en, /Berjalan|Arsip/);
+  assert.doesNotMatch(pages.id, /Running|Archive/);
+});
+
+function renderedChannelNames(html) {
+  return [...html.matchAll(/>([^<]+)<\/a>\s*<span class="cv-status">/g)].map((match) => match[1]);
+}
+
+test("current channels render before retired ones on both language pages", () => {
+  const expected = [
+    ...cv.content.channels.filter((channel) => channel.status === "current").map((c) => c.name),
+    ...cv.content.channels.filter((channel) => channel.status === "retired").map((c) => c.name),
+  ];
+
+  for (const [lang, html] of Object.entries(pages)) {
+    assert.deepEqual(renderedChannelNames(html), expected, `${lang} channel order`);
+  }
+});
+
+test("channel status count stays aligned across languages", () => {
+  assert.equal(count(pages.en, /class="cv-status"/g), count(pages.id, /class="cv-status"/g));
 });

--- a/test/cv-page.test.js
+++ b/test/cv-page.test.js
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import nunjucks from "nunjucks";
+import cv from "../src/_data/cv.js";
+import karya from "../src/_data/karya.js";
+import { formatMonth, formatPeriod, translate } from "../src/libs/cv.js";
+import { selectProjects } from "../src/libs/karya.js";
+
+const env = new nunjucks.Environment(new nunjucks.FileSystemLoader("src/_includes"), {
+  autoescape: true,
+});
+env.addFilter("translate", translate);
+env.addFilter("cvPeriod", formatPeriod);
+env.addFilter("cvMonth", formatMonth);
+
+function render(lang) {
+  return env.renderString(
+    '{% import "cv_body.njk" as cvBody %}{{ cvBody.render(cv, lang, projects) }}',
+    { cv, lang, projects: selectProjects(karya) },
+  );
+}
+
+const pages = { id: render("id"), en: render("en") };
+
+function sectionIds(html) {
+  return [...html.matchAll(/<section[^>]*\sid="([^"]+)"/g)].map((match) => match[1]);
+}
+
+function count(html, pattern) {
+  return (html.match(pattern) || []).length;
+}
+
+test("both language versions render", () => {
+  for (const [lang, html] of Object.entries(pages)) {
+    assert.ok(html.trim().length > 2000, `${lang} rendered suspiciously short`);
+    assert.match(html, /Riza Fahmi/);
+  }
+});
+
+// Two hand-maintained copies drift the moment one is edited. Both pages are
+// rendered from one macro over one data file, so the shape must match exactly.
+test("the two languages stay in sync structurally", () => {
+  assert.deepEqual(sectionIds(pages.en), sectionIds(pages.id));
+  assert.ok(sectionIds(pages.id).length >= 8, "the CV should have its full section set");
+
+  for (const pattern of [/class="cv-entry"/g, /class="cv-role"/g, /class="cv-project"/g]) {
+    assert.equal(
+      count(pages.en, pattern),
+      count(pages.id, pattern),
+      `${pattern} count differs between languages`,
+    );
+  }
+});
+
+test("neither language leaks a location or a phone number", () => {
+  for (const [lang, html] of Object.entries(pages)) {
+    assert.doesNotMatch(html, /Banten/i, `${lang} leaks a location`);
+    assert.doesNotMatch(html, /tel:/i, `${lang} leaks a phone link`);
+    assert.doesNotMatch(html, /\+62/, `${lang} leaks a phone number`);
+  }
+});
+
+test("both languages publish the email and every profile link", () => {
+  for (const [lang, html] of Object.entries(pages)) {
+    assert.match(html, /mailto:rizafahmi@gmail\.com/, `${lang} is missing the email`);
+    for (const profile of cv.identity.profiles) {
+      assert.ok(html.includes(profile.url), `${lang} is missing ${profile.url}`);
+    }
+  }
+});
+
+test("each language renders its own prose, not the other one's", () => {
+  assert.match(pages.id, /Sekarang/);
+  assert.match(pages.en, /Present/);
+  assert.doesNotMatch(pages.en, /Pengalaman Kerja/);
+  assert.doesNotMatch(pages.id, /Work Experience/);
+});
+
+test("every curated project from Karya reaches the CV", () => {
+  const projects = selectProjects(karya);
+  for (const [lang, html] of Object.entries(pages)) {
+    assert.equal(count(html, /class="cv-project"/g), projects.length, `${lang} project count`);
+    for (const project of projects) {
+      assert.ok(html.includes(project.name), `${lang} is missing project ${project.name}`);
+    }
+  }
+});
+
+// On paper a link cannot be clicked, so every profile link spells out its own
+// address as the link text. Inline links elsewhere keep human labels on purpose.
+test("profile links read as their own address, so they survive being printed", () => {
+  for (const [lang, html] of Object.entries(pages)) {
+    for (const profile of cv.identity.profiles) {
+      const address = profile.url.replace("https://", "");
+      assert.ok(
+        html.includes(`>${address}</a>`),
+        `${lang} does not print the address for ${profile.url}`,
+      );
+    }
+  }
+});

--- a/test/cv.test.js
+++ b/test/cv.test.js
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import cv from "../src/_data/cv.js";
-import { formatMonth, formatPeriod, skillItems, translate } from "../src/libs/cv.js";
+import { formatMonth, formatPeriod, orderedChannels, skillItems, translate } from "../src/libs/cv.js";
 
 test("formatMonth renders month precision in the page language", () => {
   assert.equal(formatMonth("2018-11", "id"), "November 2018");
@@ -160,4 +160,45 @@ test("education lists both degrees, most recent first", () => {
   assert.equal(cv.education.length, 2);
   assert.match(cv.education[0].school, /University of Indonesia/);
   assert.match(cv.education[1].school, /BINUS/);
+});
+
+// Captain-confirmed 2026-08-21: only Ngobrolin Web and YouTube are still running.
+// Status lives as a machine value on each channel so flipping one is a one-word edit.
+test("every content channel carries a current or retired status", () => {
+  assert.ok(cv.content.channels.length >= 5);
+  for (const channel of cv.content.channels) {
+    assert.ok(
+      channel.status === "current" || channel.status === "retired",
+      `${channel.name} needs status "current" or "retired"`,
+    );
+  }
+});
+
+test("exactly Ngobrolin Web and YouTube are current channels", () => {
+  const current = cv.content.channels
+    .filter((channel) => channel.status === "current")
+    .map((channel) => channel.name);
+  assert.deepEqual(current, ["Ngobrolin Web", "YouTube"]);
+});
+
+test("exactly AppsCoast, Ceritanya Developer, and Hikayat are retired", () => {
+  const retired = cv.content.channels
+    .filter((channel) => channel.status === "retired")
+    .map((channel) => channel.name);
+  assert.deepEqual(
+    new Set(retired),
+    new Set(["AppsCoast", "Ceritanya Developer", "Hikayat Punggawa Teknologi"]),
+  );
+  assert.equal(retired.length, 3);
+});
+
+test("current channels keep their relative order ahead of retired ones", () => {
+  const ordered = orderedChannels(cv.content.channels).map((channel) => channel.name);
+  assert.deepEqual(ordered, [
+    "Ngobrolin Web",
+    "YouTube",
+    "Ceritanya Developer",
+    "Hikayat Punggawa Teknologi",
+    "AppsCoast",
+  ]);
 });

--- a/test/cv.test.js
+++ b/test/cv.test.js
@@ -2,7 +2,13 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import cv from "../src/_data/cv.js";
-import { formatMonth, formatPeriod, orderedChannels, skillItems, translate } from "../src/libs/cv.js";
+import {
+  formatMonth,
+  formatPeriod,
+  orderedChannels,
+  skillItems,
+  translate,
+} from "../src/libs/cv.js";
 
 test("formatMonth renders month precision in the page language", () => {
   assert.equal(formatMonth("2018-11", "id"), "November 2018");

--- a/test/cv.test.js
+++ b/test/cv.test.js
@@ -1,0 +1,163 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import cv from "../src/_data/cv.js";
+import { formatMonth, formatPeriod, skillItems, translate } from "../src/libs/cv.js";
+
+test("formatMonth renders month precision in the page language", () => {
+  assert.equal(formatMonth("2018-11", "id"), "November 2018");
+  assert.equal(formatMonth("2018-11", "en"), "November 2018");
+  assert.equal(formatMonth("2007-05", "id"), "Mei 2007");
+  assert.equal(formatMonth("2007-05", "en"), "May 2007");
+  assert.equal(formatMonth("2016-03", "id"), "Maret 2016");
+  assert.equal(formatMonth("2016-03", "en"), "March 2016");
+});
+
+test("formatMonth keeps year-only dates as plain years", () => {
+  assert.equal(formatMonth("2011", "id"), "2011");
+  assert.equal(formatMonth("2011", "en"), "2011");
+});
+
+test("formatPeriod joins start and end with an en dash", () => {
+  assert.equal(
+    formatPeriod({ start: "2016-03", end: "2018-11" }, "id"),
+    "Maret 2016 – November 2018",
+  );
+  assert.equal(formatPeriod({ start: "2003", end: "2007-05" }, "en"), "2003 – May 2007");
+});
+
+// "Present" must be rendered from an open-ended role, never baked into the data,
+// so the page stays honest however long it sits on the site.
+test("formatPeriod renders an open-ended role as Sekarang / Present", () => {
+  assert.equal(formatPeriod({ start: "2018-11", end: null }, "id"), "November 2018 – Sekarang");
+  assert.equal(formatPeriod({ start: "2018-11", end: null }, "en"), "November 2018 – Present");
+});
+
+test("translate picks the requested language and falls back to Indonesian", () => {
+  assert.equal(translate({ id: "Halo", en: "Hello" }, "en"), "Hello");
+  assert.equal(translate({ id: "Halo", en: "Hello" }, "id"), "Halo");
+  assert.equal(translate({ id: "Halo" }, "en"), "Halo");
+  assert.equal(translate("Elixir", "en"), "Elixir");
+  assert.equal(translate(null, "en"), "");
+});
+
+test("the CV publishes Indonesian and English only", () => {
+  assert.deepEqual(cv.languages, ["id", "en"]);
+  assert.equal(cv.meta.id.permalink, "/cv/");
+  assert.equal(cv.meta.en.permalink, "/cv/en/");
+});
+
+// The captain decided email is the only personal detail on this public,
+// permanent page. A scraped address or phone number cannot be recalled.
+test("the CV data carries no location and no phone number", () => {
+  const serialized = JSON.stringify(cv);
+  assert.doesNotMatch(serialized, /Banten/i);
+  assert.doesNotMatch(serialized, /\btel:/i);
+  assert.doesNotMatch(serialized, /\+62/);
+  assert.doesNotMatch(serialized, /\b08\d{8,}\b/);
+});
+
+test("the CV data carries the email and the public profile links", () => {
+  assert.equal(cv.identity.email, "rizafahmi@gmail.com");
+  const urls = cv.identity.profiles.map((profile) => profile.url);
+  assert.deepEqual(urls, [
+    "https://rizafahmi.com",
+    "https://github.com/rizafahmi",
+    "https://linkedin.com/in/rizafahmi",
+    "https://x.com/rizafahmi22",
+    "https://youtube.com/rizafahmi",
+  ]);
+});
+
+// LinkedIn's "Top Skills" are endorsement artifacts that misrepresent current
+// work. They may appear as history inside an old role, never as a skill.
+test("the skill list does not republish LinkedIn's endorsement artifacts", () => {
+  const items = skillItems(cv).map((item) => item.toLowerCase());
+  for (const banned of ["mysql", "postgresql", "php"]) {
+    assert.ok(!items.includes(banned), `skills must not list ${banned}`);
+  }
+});
+
+test("the skill list is drawn from the current, evidenced stack", () => {
+  const items = skillItems(cv);
+  for (const expected of ["Elixir", "Phoenix LiveView", "TypeScript", "Astro", "SQLite"]) {
+    assert.ok(items.includes(expected), `skills should list ${expected}`);
+  }
+});
+
+// Captain instruction, 2026-08-21: the AppsCO: Apps Colony role is off the CV
+// entirely, and the dead appsco.id link with it. AppsCoast — a different thing,
+// a podcast still listed on /showcase/ — is deliberately not covered by this.
+test("the AppsCO employer and its dead domain are gone", () => {
+  const serialized = JSON.stringify(cv);
+  assert.doesNotMatch(serialized, /Apps\s*Colony/i);
+  assert.doesNotMatch(serialized, /appsco\.id/i);
+  assert.equal(cv.experience.filter((entry) => /^AppsCO\b/i.test(entry.org)).length, 0);
+});
+
+// Seven employers, eight roles — Hacktiv8 accounts for two of them.
+test("the experience list is the eight roles the captain signed off", () => {
+  assert.equal(cv.experience.length, 7);
+  assert.equal(
+    cv.experience.reduce((total, entry) => total + entry.roles.length, 0),
+    8,
+  );
+});
+
+// PT. IONSOFT and IYAA.com are one job under two names, not two jobs.
+test("IONSOFT and IYAA are a single experience entry", () => {
+  const matches = cv.experience.filter((entry) => /IONSOFT|IYAA/i.test(entry.org));
+  assert.equal(matches.length, 1);
+  assert.match(matches[0].org, /IONSOFT/);
+  assert.match(matches[0].org, /IYAA/);
+});
+
+test("experience runs most recent first and every role has a start date", () => {
+  const starts = cv.experience.map((entry) => entry.roles[0].start);
+  const sorted = [...starts].sort().reverse();
+  assert.deepEqual(starts, sorted);
+
+  for (const entry of cv.experience) {
+    assert.ok(entry.roles.length > 0, `${entry.org} needs at least one role`);
+    for (const role of entry.roles) {
+      assert.match(role.start, /^\d{4}(-\d{2})?$/, `${entry.org} has an unparseable start`);
+    }
+  }
+});
+
+// The export's stated durations were computed at export time and are stale.
+test("no experience entry hard-codes a duration or the word Present", () => {
+  const serialized = JSON.stringify(cv.experience);
+  assert.doesNotMatch(serialized, /\d+\s+(year|month|tahun|bulan)/i);
+  assert.doesNotMatch(serialized, /"Present"/);
+  assert.doesNotMatch(serialized, /"Sekarang"/);
+});
+
+test("every experience entry carries both languages for its prose", () => {
+  for (const entry of cv.experience) {
+    assert.ok(entry.summary.id, `${entry.org} is missing Indonesian prose`);
+    assert.ok(entry.summary.en, `${entry.org} is missing English prose`);
+    for (const role of entry.roles) {
+      assert.ok(role.title.id && role.title.en, `${entry.org} has an untranslated role title`);
+    }
+  }
+});
+
+// http://appsco.id no longer resolves; a CV advertising a dead link is worse
+// than one without.
+test("the dead appsco.id link is not published", () => {
+  assert.doesNotMatch(JSON.stringify(cv), /appsco\.id/i);
+});
+
+test("publications are listed without guessed URLs", () => {
+  assert.equal(cv.honours.publications.length, 4);
+  for (const publication of cv.honours.publications) {
+    assert.equal(typeof publication, "string");
+  }
+});
+
+test("education lists both degrees, most recent first", () => {
+  assert.equal(cv.education.length, 2);
+  assert.match(cv.education[0].school, /University of Indonesia/);
+  assert.match(cv.education[1].school, /BINUS/);
+});


### PR DESCRIPTION
## Intent

Build a bilingual CV on rizafahmi.com that prints to a clean PDF straight from the browser. General-purpose (balanced across employment, consulting and speaking, with sections a reader can trim so the captain can tailor it per audience), living as a page on the site, in both Indonesian at /cv/ and English at /cv/en/, built from the captain's LinkedIn export reconciled with material already on the site.

CONTENT SOURCE OF TRUTH. Every fact comes from a firstmate-maintained source file already reconciled with the captain's own corrections, plus the live site. Nothing biographical was invented, embellished or inferred beyond those two sources.

NON-NEGOTIABLE CAPTAIN DECISIONS, all deliberate and all visible in the diff:
1. Email (rizafahmi@gmail.com) is the ONLY personal contact detail, plus public profile links. NO phone number and NO location anywhere - not in visible content, not in meta tags, not in JSON-LD structured data, not in the print output. The LinkedIn export says 'Banten, Indonesia'; it must never appear. This page is public and permanent and a scraped address cannot be recalled. Tests enforce this.
2. LinkedIn's 'Top Skills' (MySQL, PostgreSQL, PHP) are endorsement artifacts and are deliberately NOT published as skills. The skill list is drawn from evidence: src/_data/karya.js tags, the topic hubs, and recent writing. Those three technologies DO still appear inside old role descriptions (Okezone, Linuxindo, Ainetworks) - that is correct history, not a skills claim, and is intentional.
3. PT. IONSOFT and IYAA.com are ONE job under two names, not two jobs. LinkedIn lists them as two entries with identical date ranges. They are deliberately merged into a single experience entry.
4. SUPERSEDING INSTRUCTION from the captain mid-task: 'AppsCO: Apps Colony' (Managing Director, Jan-Dec 2015) has been REMOVED from the CV entirely, and the dead appsco.id link with it. The experience list is 7 employers / 8 roles, not 9 roles. Do not flag its absence as an omission.
5. 'AppsCoast' - a podcast, a DIFFERENT entity from AppsCO the employer - is deliberately KEPT in the content/podcast list. It is still listed on the live /showcase/ page, sits in a made-work list, and is not claimed as current. The captain explicitly confirmed keeping it. The near-identical name is not a bug.
6. Durations are NOT hard-coded. The export's stated durations ('7 years 1 month') were computed at export time and are already stale. Only date ranges are stored; an open-ended role stores end:null and renders 'Sekarang'/'Present' at build time so it stays honest as time passes. This is why no duration arithmetic appears anywhere.
7. Publications are listed as plain text with NO links, because the export has no URLs and guessing a URL on a CV is worse than omitting it. Similarly only hacktiv8.com is linked among employers - the others' URLs are not established by the sources, so they are deliberately unlinked. appsco.id was verified dead (NXDOMAIN) before being dropped.

WRITTEN ONCE, NOT TWICE. Two hand-maintained language copies would drift the moment one is edited. So: src/_data/cv.js holds every fact as an { id, en } pair, hand-editable and comment-documented in Indonesian, deliberately matching the spirit of the existing src/_data/karya.js which the captain edits by hand - obvious, no cleverness. src/cv.njk is ONE template that paginates over cv.languages to emit BOTH pages; src/_includes/cv_body.njk is the only markup; src/libs/cv.js holds the formatting helpers. The 13 curated open source projects are pulled LIVE from karya.js rather than copied, so they cannot drift either.

PAGE LANGUAGE, solved the least invasive way. Every existing layout (main.njk, tulisan.njk, serial.njk) hardcodes <html lang="id">, which is CORRECT for every page they serve, so all three are deliberately left untouched - no regression to existing Indonesian pages. The CV instead gets its own layout, src/_includes/cv.njk, which sets lang per page. src/_includes/head.njk gained three OPTIONAL page-data fields with Indonesian defaults - pageLocale (og:locale), pageLangTag (JSON-LD inLanguage on the WebPage node only; the WebSite node stays id-ID because the site itself is Indonesian-first), and alternates (hreflang list). Built output for existing pages was diffed and is unchanged. Site chrome stays in Indonesian on the English page and is marked lang="id" so screen readers do not read it as English. Both pages cross-link and carry id / en / x-default hreflang alternates.

THE PRINT OUTPUT IS THE ACTUAL DELIVERABLE, not a nice-to-have. assets/cv.css: @page size A4 with 15mm margins (longhand margin properties, not shorthand, purely to satisfy a biome noShorthandPropertyOverrides false positive on @page - the comment says so). All site chrome stripped on print (header, nav, theme toggle, print button, language switcher, back link, skip link). Plain black on white with no reliance on background colours, because many printers drop backgrounds by default. Deliberate page breaks: break-after:avoid on headings and roles so a heading never sits alone at the foot of a page, break-inside:avoid on entries, skill groups and the two project lists so no entry splits mid-item, orphans/widows 3. Link handling was decided deliberately: profile links spell out their own address as the link text (github.com/rizafahmi, linkedin.com/in/rizafahmi, ...) because a link cannot be clicked on paper, while inline links elsewhere keep human labels on purpose - a CV full of long URLs is worse than one without. Document titles ('CV Riza Fahmi', 'Riza Fahmi - CV') are chosen because they become the PDF filename.

VERIFIED BY ACTUALLY PRINTING, not by eyeballing the screen: real PDFs generated from headless Chrome against the built pages. 4 pages each, MediaBox 595x842pt confirming A4; US Letter (612x792pt) also renders in 4 pages as a bonus. Every page was read back as an image and three real layout defects were found and fixed that way: a mid-address line break in the contact block, an orphaned three-item run of the project list, and a doubled horizontal rule under the header.

DISCOVERABILITY: both URLs added to the sitemap static page list and to llms.txt, following what those files already do. Whether it earns a nav link was a judgement call: the smallest sensible choice was taken - ONE link on the home page's existing secondary link row next to Uses and Now, and deliberately NO change to the primary nav. Only the Indonesian CV is opted into the Pagefind index; the English one carries data-pagefind-ignore to avoid a near-duplicate search result.

SCOPE CONSTRAINTS the captain set, all respected: do not restructure src/showcase.njk, src/_data/karya.js, or any existing page beyond what the lang fix genuinely requires; do not add a [build] section to netlify.toml; do not add an i18n framework or any dependency - the project just consolidated onto pnpm with a deliberately small dependency set, and this change adds zero dependencies.

TDD was applied: failing tests first, then implementation. test/cv.test.js and test/cv-page.test.js pin that both pages build/render, that neither contains the omitted personal details (no location, no phone, no tel:), that the two languages stay in sync structurally (identical section ids, identical entry/role/project counts), that the banned skills stay out of the skill list, that IONSOFT/IYAA stay merged, that AppsCO and appsco.id stay gone, and that no stale duration is hard-coded.

The package manager is pnpm - not npm, not bun. pnpm run check (91 tests) and pnpm run build (which includes the site audit) both pass.

## What Changed

- Add bilingual CV pages at `/cv/` and `/cv/en/` from a single curated `{ id, en }` data source, one shared template/body, formatting helpers, and print CSS that strips site chrome for clean A4 browser-to-PDF output
- Wire optional locale/hreflang fields in `head.njk`, link CV from the homepage secondary row, list both URLs in sitemap and `llms.txt`, and pull open-source entries live from `karya.js`
- Add CV unit and page tests that pin bilingual structure sync, omitted personal details, merged IONSOFT/IYAA, AppsCO removal, and skills curation; refresh AGENTS.md CV docs

## Risk Assessment

✅ Low: Prior-round defects are fixed, captain constraints hold in source, and the bilingual CV architecture remains bounded with no remaining source-verifiable merge blockers.

## Testing

Ran the focused CV unit/page tests (all passed), built the site, then verified end-user behavior with screen screenshots plus real A4 print PDFs (4 pages each, chrome stripped, privacy/content rules intact) and a homepage shot showing the CV secondary link; overall result pass.

- Evidence: Indonesian CV on-screen (/cv/) (local file: <code>/var/folders/56/2m6tn38j08j1ypyx86tvpz5c0000gn/T/no-mistakes-evidence/01M0J2FFW63T14B42BG5WRNQNE/cv-id-screen.png</code>)
- Evidence: English CV on-screen (/cv/en/) (local file: <code>/var/folders/56/2m6tn38j08j1ypyx86tvpz5c0000gn/T/no-mistakes-evidence/01M0J2FFW63T14B42BG5WRNQNE/cv-en-screen.png</code>)
- Evidence: Homepage secondary row with Uses / Now / CV (local file: <code>/var/folders/56/2m6tn38j08j1ypyx86tvpz5c0000gn/T/no-mistakes-evidence/01M0J2FFW63T14B42BG5WRNQNE/home-cv-link.png</code>)
<details>
<summary>Evidence: Indonesian CV print PDF (A4, 4 pages)</summary>

```text
%PDF-1.4
%

... [283170 bytes truncated] ...


0000094937 00000 n 
0000095277 00000 n 
0000095590 00000 n 
0000095959 00000 n 
0000096297 00000 n 
0000096917 00000 n 
0000097064 00000 n 
0000097326 00000 n 
0000097477 00000 n 
0000097664 00000 n 
0000097853 00000 n 
0000098017 00000 n 
0000098175 00000 n 
0000098714 00000 n 
0000099181 00000 n 
0000099608 00000 n 
0000100102 00000 n 
0000100402 00000 n 
0000100956 00000 n 
0000101256 00000 n 
0000101537 00000 n 
0000101933 00000 n 
0000102099 00000 n 
0000102252 00000 n 
0000102654 00000 n 
0000102952 00000 n 
0000103367 00000 n 
0000103787 00000 n 
0000104076 00000 n 
0000104624 00000 n 
0000104930 00000 n 
0000105234 00000 n 
0000105384 00000 n 
0000105566 00000 n 
0000105756 00000 n 
0000106053 00000 n 
0000106120 00000 n 
0000106348 00000 n 
0000106577 00000 n 
0000106674 00000 n 
0000107544 00000 n 
0000108020 00000 n 
0000110700 00000 n 
0000110851 00000 n 
0000111593 00000 n 
0000112076 00000 n 
0000112559 00000 n 
0000113053 00000 n 
0000113614 00000 n 
0000113847 00000 n 
0000114774 00000 n 
0000115086 00000 n 
0000115349 00000 n 
0000115522 00000 n 
0000115741 00000 n 
0000116232 00000 n 
0000116550 00000 n 
0000116971 00000 n 
0000117290 00000 n 
0000117535 00000 n 
0000117862 00000 n 
0000118032 00000 n 
0000118277 00000 n 
0000118435 00000 n 
0000118905 00000 n 
0000119145 00000 n 
0000119277 00000 n 
0000120364 00000 n 
0000120765 00000 n 
0000123036 00000 n 
0000123234 00000 n 
0000123911 00000 n 
0000124111 00000 n 
0000124330 00000 n 
0000124722 00000 n 
0000125147 00000 n 
0000125314 00000 n 
0000125539 00000 n 
0000126234 00000 n 
0000126937 00000 n 
0000127566 00000 n 
0000128267 00000 n 
0000129266 00000 n 
0000129737 00000 n 
0000129994 00000 n 
0000130254 00000 n 
0000130462 00000 n 
0000130573 00000 n 
0000131238 00000 n 
0000131710 00000 n 
0000132367 00000 n 
0000133069 00000 n 
0000133537 00000 n 
0000133976 00000 n 
0000134447 00000 n 
0000134869 00000 n 
0000134942 00000 n 
0000135920 00000 n 
0000136337 00000 n 
0000138723 00000 n 
0000138921 00000 n 
0000139649 00000 n 
0000140614 00000 n 
0000141529 00000 n 
0000141680 00000 n 
0000141847 00000 n 
0000142366 00000 n 
0000142867 00000 n 
0000143208 00000 n 
0000143368 00000 n 
0000143522 00000 n 
0000144080 00000 n 
0000144234 00000 n 
0000144387 00000 n 
0000144880 00000 n 
0000145181 00000 n 
0000145465 00000 n 
0000146222 00000 n 
0000146371 00000 n 
0000146549 00000 n 
0000147291 00000 n 
0000147774 00000 n 
0000148257 00000 n 
0000148751 00000 n 
0000149312 00000 n 
0000149545 00000 n 
0000150472 00000 n 
0000150784 00000 n 
0000151047 00000 n 
0000151377 00000 n 
0000151550 00000 n 
0000151769 00000 n 
0000152260 00000 n 
0000152578 00000 n 
0000152999 00000 n 
0000153487 00000 n 
0000153806 00000 n 
0000154520 00000 n 
0000154765 00000 n 
0000155092 00000 n 
0000155245 00000 n 
0000155425 00000 n 
0000155595 00000 n 
0000155840 00000 n 
0000156194 00000 n 
0000156445 00000 n 
0000156915 00000 n 
0000157594 00000 n 
0000157773 00000 n 
0000158279 00000 n 
0000158968 00000 n 
0000159680 00000 n 
0000159747 00000 n 
0000159987 00000 n 
0000160321 00000 n 
0000160663 00000 n 
0000160762 00000 n 
0000160864 00000 n 
0000161725 00000 n 
0000162207 00000 n 
0000164979 00000 n 
0000165130 00000 n 
0000165297 00000 n 
0000165816 00000 n 
0000166317 00000 n 
0000166658 00000 n 
0000166818 00000 n 
0000166972 00000 n 
0000167530 00000 n 
0000167684 00000 n 
0000167837 00000 n 
0000168188 00000 n 
0000168357 00000 n 
0000168496 00000 n 
0000168677 00000 n 
0000168844 00000 n 
0000169337 00000 n 
0000169638 00000 n 
0000170230 00000 n 
0000170514 00000 n 
0000171271 00000 n 
0000171420 00000 n 
0000171737 00000 n 
0000171892 00000 n 
0000172070 00000 n 
0000172243 00000 n 
0000172404 00000 n 
0000173146 00000 n 
0000173629 00000 n 
0000174112 00000 n 
0000174606 00000 n 
0000175167 00000 n 
0000175400 00000 n 
0000176327 00000 n 
0000176639 00000 n 
0000176902 00000 n 
0000177232 00000 n 
0000177405 00000 n 
0000177624 00000 n 
0000178115 00000 n 
0000178433 00000 n 
0000178854 00000 n 
0000179342 00000 n 
0000179661 00000 n 
0000180375 00000 n 
0000180620 00000 n 
0000180947 00000 n 
0000181100 00000 n 
0000181280 00000 n 
0000181450 00000 n 
0000181695 00000 n 
0000181853 00000 n 
0000182217 00000 n 
0000182571 00000 n 
0000182822 00000 n 
0000183292 00000 n 
0000183971 00000 n 
0000184150 00000 n 
0000184656 00000 n 
0000185373 00000 n 
0000185440 00000 n 
0000185680 00000 n 
0000186014 00000 n 
0000186356 00000 n 
0000186596 00000 n 
0000186789 00000 n 
0000186921 00000 n 
0000187020 00000 n 
0000187122 00000 n 
0000187403 00000 n 
0000187681 00000 n 
0000188542 00000 n 
0000189072 00000 n 
0000192112 00000 n 
0000192310 00000 n 
0000192516 00000 n 
0000193193 00000 n 
0000193881 00000 n 
0000194098 00000 n 
0000194286 00000 n 
0000194481 00000 n 
0000194594 00000 n 
0000194760 00000 n 
0000194954 00000 n 
0000195546 00000 n 
0000195938 00000 n 
0000196858 00000 n 
0000197025 00000 n 
0000197470 00000 n 
0000197673 00000 n 
0000198368 00000 n 
0000199071 00000 n 
0000199700 00000 n 
0000200401 00000 n 
0000200808 00000 n 
0000201065 00000 n 
0000201273 00000 n 
0000201384 00000 n 
0000202049 00000 n 
0000202521 00000 n 
0000203178 00000 n 
0000203880 00000 n 
0000204348 00000 n 
0000204787 00000 n 
0000205258 00000 n 
0000205441 00000 n 
0000205662 00000 n 
0000205886 00000 n 
0000206308 00000 n 
0000206509 00000 n 
0000207324 00000 n 
0000207397 00000 n 
0000207758 00000 n 
0000207908 00000 n 
0000208239 00000 n 
0000208569 00000 n 
0000209038 00000 n 
0000211625 00000 n 
0000211823 00000 n 
0000212551 00000 n 
0000213516 00000 n 
0000214432 00000 n 
0000214583 00000 n 
0000215298 00000 n 
0000215750 00000 n 
0000215934 00000 n 
0000216119 00000 n 
0000216303 00000 n 
0000216462 00000 n 
0000216687 00000 n 
0000217376 00000 n 
0000217778 00000 n 
0000218147 00000 n 
0000219262 00000 n 
0000219430 00000 n 
0000220521 00000 n 
0000221240 00000 n 
0000221927 00000 n 
0000222737 00000 n 
0000223029 00000 n 
0000224407 00000 n 
0000224838 00000 n 
0000225096 00000 n 
0000225425 00000 n 
0000225637 00000 n 
0000225907 00000 n 
0000226622 00000 n 
0000227050 00000 n 
0000227697 00000 n 
0000228397 00000 n 
0000228822 00000 n 
0000229899 00000 n 
0000230208 00000 n 
0000230668 00000 n 
0000230849 00000 n 
0000231175 00000 n 
0000231643 00000 n 
0000231953 00000 n 
0000232639 00000 n 
0000232712 00000 n 
0000233180 00000 n 
0000233308 00000 n 
0000233664 00000 n 
0000234016 00000 n 
0000235308 00000 n 
0000235791 00000 n 
0000238615 00000 n 
0000238783 00000 n 
0000238950 00000 n 
0000239105 00000 n 
0000239426 00000 n 
0000239606 00000 n 
0000239773 00000 n 
0000240393 00000 n 
0000240932 00000 n 
0000241349 00000 n 
0000241843 00000 n 
0000242397 00000 n 
0000242678 00000 n 
0000242844 00000 n 
0000242997 00000 n 
0000243399 00000 n 
0000243697 00000 n 
0000244112 00000 n 
0000244532 00000 n 
0000244821 00000 n 
0000245369 00000 n 
0000245675 00000 n 
0000245979 00000 n 
0000246129 00000 n 
0000246495 00000 n 
0000246659 00000 n 
0000247061 00000 n 
0000247703 00000 n 
0000248204 00000 n 
0000248730 00000 n 
0000248880 00000 n 
0000249517 00000 n 
0000250041 00000 n 
0000250108 00000 n 
0000250205 00000 n 
0000250634 00000 n 
0000252837 00000 n 
0000252988 00000 n 
0000253298 00000 n 
0000253525 00000 n 
0000254594 00000 n 
0000254906 00000 n 
0000256339 00000 n 
0000256526 00000 n 
0000256739 00000 n 
0000257324 00000 n 
0000257945 00000 n 
0000258133 00000 n 
0000258310 00000 n 
0000258716 00000 n 
0000258909 00000 n 
0000259068 00000 n 
0000259284 00000 n 
0000259723 00000 n 
0000260139 00000 n 
0000260607 00000 n 
0000261520 00000 n 
0000261879 00000 n 
0000262085 00000 n 
0000262158 00000 n 
0000262538 00000 n 
0000264449 00000 n 
0000264617 00000 n 
0000264784 00000 n 
0000265062 00000 n 
0000265601 00000 n 
0000266018 00000 n 
0000266512 00000 n 
0000267066 00000 n 
0000267347 00000 n 
0000267767 00000 n 
0000268056 00000 n 
0000268604 00000 n 
0000268910 00000 n 
0000269214 00000 n 
0000269580 00000 n 
0000269982 00000 n 
0000270508 00000 n 
0000270575 00000 n 
0000270961 00000 n 
trailer
<</Size 926
/Root 470 0 R
/Info 1 0 R>>
startxref
272770
%%EOF
```
</details>
<details>
<summary>Evidence: English CV print PDF (A4, 4 pages)</summary>

```text
%PDF-1.4
%

... [282452 bytes truncated] ...


0000094696 00000 n 
0000094863 00000 n 
0000095203 00000 n 
0000095516 00000 n 
0000095885 00000 n 
0000096223 00000 n 
0000096843 00000 n 
0000096990 00000 n 
0000097252 00000 n 
0000097403 00000 n 
0000097590 00000 n 
0000097779 00000 n 
0000097943 00000 n 
0000098101 00000 n 
0000098640 00000 n 
0000099107 00000 n 
0000099534 00000 n 
0000100028 00000 n 
0000100328 00000 n 
0000100882 00000 n 
0000101182 00000 n 
0000101463 00000 n 
0000101859 00000 n 
0000102025 00000 n 
0000102178 00000 n 
0000102580 00000 n 
0000102878 00000 n 
0000103293 00000 n 
0000103713 00000 n 
0000104002 00000 n 
0000104550 00000 n 
0000104856 00000 n 
0000105160 00000 n 
0000105310 00000 n 
0000105492 00000 n 
0000105682 00000 n 
0000105979 00000 n 
0000106046 00000 n 
0000106274 00000 n 
0000106503 00000 n 
0000106600 00000 n 
0000107470 00000 n 
0000107946 00000 n 
0000110626 00000 n 
0000110777 00000 n 
0000111519 00000 n 
0000112002 00000 n 
0000112485 00000 n 
0000112979 00000 n 
0000113540 00000 n 
0000113773 00000 n 
0000114700 00000 n 
0000115012 00000 n 
0000115275 00000 n 
0000115448 00000 n 
0000115667 00000 n 
0000116158 00000 n 
0000116476 00000 n 
0000116897 00000 n 
0000117216 00000 n 
0000117461 00000 n 
0000117788 00000 n 
0000117958 00000 n 
0000118203 00000 n 
0000118361 00000 n 
0000118831 00000 n 
0000119071 00000 n 
0000119203 00000 n 
0000120290 00000 n 
0000120691 00000 n 
0000122962 00000 n 
0000123160 00000 n 
0000123848 00000 n 
0000124065 00000 n 
0000124260 00000 n 
0000124426 00000 n 
0000124818 00000 n 
0000125738 00000 n 
0000125905 00000 n 
0000126130 00000 n 
0000126825 00000 n 
0000127528 00000 n 
0000128157 00000 n 
0000128858 00000 n 
0000129857 00000 n 
0000130328 00000 n 
0000130585 00000 n 
0000130793 00000 n 
0000130904 00000 n 
0000131569 00000 n 
0000132041 00000 n 
0000132698 00000 n 
0000133400 00000 n 
0000133868 00000 n 
0000134307 00000 n 
0000134778 00000 n 
0000135002 00000 n 
0000135424 00000 n 
0000135497 00000 n 
0000136475 00000 n 
0000136898 00000 n 
0000139308 00000 n 
0000139459 00000 n 
0000139626 00000 n 
0000140145 00000 n 
0000140646 00000 n 
0000140987 00000 n 
0000141147 00000 n 
0000141705 00000 n 
0000141859 00000 n 
0000142012 00000 n 
0000142193 00000 n 
0000142686 00000 n 
0000142970 00000 n 
0000143727 00000 n 
0000143876 00000 n 
0000144054 00000 n 
0000144796 00000 n 
0000145279 00000 n 
0000145762 00000 n 
0000146256 00000 n 
0000146817 00000 n 
0000147050 00000 n 
0000147977 00000 n 
0000148289 00000 n 
0000148552 00000 n 
0000148882 00000 n 
0000149055 00000 n 
0000149274 00000 n 
0000149765 00000 n 
0000150083 00000 n 
0000150504 00000 n 
0000150992 00000 n 
0000151311 00000 n 
0000152025 00000 n 
0000152270 00000 n 
0000152597 00000 n 
0000152750 00000 n 
0000152930 00000 n 
0000153100 00000 n 
0000153345 00000 n 
0000153699 00000 n 
0000153950 00000 n 
0000154420 00000 n 
0000155099 00000 n 
0000155278 00000 n 
0000155784 00000 n 
0000156473 00000 n 
0000157185 00000 n 
0000157252 00000 n 
0000157492 00000 n 
0000157826 00000 n 
0000158168 00000 n 
0000158267 00000 n 
0000158406 00000 n 
0000159267 00000 n 
0000159749 00000 n 
0000162502 00000 n 
0000162700 00000 n 
0000163428 00000 n 
0000164393 00000 n 
0000165309 00000 n 
0000165460 00000 n 
0000165627 00000 n 
0000166146 00000 n 
0000166647 00000 n 
0000166988 00000 n 
0000167148 00000 n 
0000167302 00000 n 
0000167860 00000 n 
0000168014 00000 n 
0000168167 00000 n 
0000168518 00000 n 
0000168687 00000 n 
0000168826 00000 n 
0000169007 00000 n 
0000169174 00000 n 
0000169667 00000 n 
0000169968 00000 n 
0000170560 00000 n 
0000170844 00000 n 
0000171601 00000 n 
0000171750 00000 n 
0000172067 00000 n 
0000172222 00000 n 
0000172400 00000 n 
0000172573 00000 n 
0000172734 00000 n 
0000173476 00000 n 
0000173959 00000 n 
0000174442 00000 n 
0000174936 00000 n 
0000175497 00000 n 
0000175730 00000 n 
0000176657 00000 n 
0000176969 00000 n 
0000177232 00000 n 
0000177562 00000 n 
0000177735 00000 n 
0000177954 00000 n 
0000178445 00000 n 
0000178763 00000 n 
0000179184 00000 n 
0000179672 00000 n 
0000179991 00000 n 
0000180705 00000 n 
0000180950 00000 n 
0000181277 00000 n 
0000181430 00000 n 
0000181610 00000 n 
0000181780 00000 n 
0000182025 00000 n 
0000182183 00000 n 
0000182507 00000 n 
0000182871 00000 n 
0000183225 00000 n 
0000183476 00000 n 
0000183946 00000 n 
0000184625 00000 n 
0000184804 00000 n 
0000185310 00000 n 
0000186027 00000 n 
0000186094 00000 n 
0000186334 00000 n 
0000186668 00000 n 
0000187010 00000 n 
0000187250 00000 n 
0000187443 00000 n 
0000187575 00000 n 
0000187674 00000 n 
0000187776 00000 n 
0000188057 00000 n 
0000188335 00000 n 
0000189196 00000 n 
0000189730 00000 n 
0000192787 00000 n 
0000192985 00000 n 
0000193191 00000 n 
0000193868 00000 n 
0000194556 00000 n 
0000194773 00000 n 
0000194961 00000 n 
0000195156 00000 n 
0000195269 00000 n 
0000195435 00000 n 
0000195629 00000 n 
0000196221 00000 n 
0000196613 00000 n 
0000197533 00000 n 
0000197700 00000 n 
0000198145 00000 n 
0000198348 00000 n 
0000199043 00000 n 
0000199746 00000 n 
0000200375 00000 n 
0000201076 00000 n 
0000201483 00000 n 
0000201740 00000 n 
0000201948 00000 n 
0000202059 00000 n 
0000202724 00000 n 
0000203196 00000 n 
0000203853 00000 n 
0000204555 00000 n 
0000205023 00000 n 
0000205462 00000 n 
0000205933 00000 n 
0000206116 00000 n 
0000206337 00000 n 
0000206561 00000 n 
0000206983 00000 n 
0000207184 00000 n 
0000207999 00000 n 
0000208072 00000 n 
0000208433 00000 n 
0000208583 00000 n 
0000208914 00000 n 
0000209244 00000 n 
0000209713 00000 n 
0000212300 00000 n 
0000212498 00000 n 
0000213226 00000 n 
0000214191 00000 n 
0000215107 00000 n 
0000215258 00000 n 
0000215980 00000 n 
0000216695 00000 n 
0000217147 00000 n 
0000217331 00000 n 
0000217516 00000 n 
0000217700 00000 n 
0000217859 00000 n 
0000218084 00000 n 
0000218773 00000 n 
0000219175 00000 n 
0000219544 00000 n 
0000219712 00000 n 
0000220803 00000 n 
0000221522 00000 n 
0000222209 00000 n 
0000223019 00000 n 
0000223311 00000 n 
0000224689 00000 n 
0000225120 00000 n 
0000225378 00000 n 
0000225648 00000 n 
0000226363 00000 n 
0000226791 00000 n 
0000227438 00000 n 
0000228138 00000 n 
0000228563 00000 n 
0000229640 00000 n 
0000229949 00000 n 
0000230409 00000 n 
0000230590 00000 n 
0000230916 00000 n 
0000231384 00000 n 
0000231457 00000 n 
0000231925 00000 n 
0000232053 00000 n 
0000232208 00000 n 
0000233500 00000 n 
0000233971 00000 n 
0000236680 00000 n 
0000236848 00000 n 
0000237015 00000 n 
0000237170 00000 n 
0000237491 00000 n 
0000237671 00000 n 
0000237838 00000 n 
0000238151 00000 n 
0000238771 00000 n 
0000239310 00000 n 
0000239727 00000 n 
0000240194 00000 n 
0000240688 00000 n 
0000241242 00000 n 
0000241542 00000 n 
0000241695 00000 n 
0000242097 00000 n 
0000242395 00000 n 
0000242810 00000 n 
0000243230 00000 n 
0000243519 00000 n 
0000244067 00000 n 
0000244373 00000 n 
0000244677 00000 n 
0000244827 00000 n 
0000245124 00000 n 
0000245490 00000 n 
0000245654 00000 n 
0000246056 00000 n 
0000246698 00000 n 
0000247199 00000 n 
0000247725 00000 n 
0000247875 00000 n 
0000248512 00000 n 
0000249036 00000 n 
0000249103 00000 n 
0000249200 00000 n 
0000249637 00000 n 
0000251872 00000 n 
0000252023 00000 n 
0000252333 00000 n 
0000252560 00000 n 
0000253629 00000 n 
0000253941 00000 n 
0000255374 00000 n 
0000255561 00000 n 
0000255774 00000 n 
0000256359 00000 n 
0000256980 00000 n 
0000257168 00000 n 
0000257815 00000 n 
0000257998 00000 n 
0000258175 00000 n 
0000258368 00000 n 
0000258527 00000 n 
0000258743 00000 n 
0000259182 00000 n 
0000259598 00000 n 
0000260066 00000 n 
0000260979 00000 n 
0000261146 00000 n 
0000261505 00000 n 
0000261688 00000 n 
0000261939 00000 n 
0000262012 00000 n 
0000262388 00000 n 
0000264365 00000 n 
0000264533 00000 n 
0000264700 00000 n 
0000264962 00000 n 
0000265501 00000 n 
0000265928 00000 n 
0000266422 00000 n 
0000266976 00000 n 
0000267396 00000 n 
0000267944 00000 n 
0000268250 00000 n 
0000268554 00000 n 
0000268920 00000 n 
0000269322 00000 n 
0000269848 00000 n 
0000269915 00000 n 
0000270293 00000 n 
trailer
<</Size 925
/Root 470 0 R
/Info 1 0 R>>
startxref
272072
%%EOF
```
</details>
- Evidence: Indonesian PDF page 1 (print layout) (local file: <code>/var/folders/56/2m6tn38j08j1ypyx86tvpz5c0000gn/T/no-mistakes-evidence/01M0J2FFW63T14B42BG5WRNQNE/pdf-pages/cv-id-1.png</code>)
- Evidence: Indonesian PDF page 2 (local file: <code>/var/folders/56/2m6tn38j08j1ypyx86tvpz5c0000gn/T/no-mistakes-evidence/01M0J2FFW63T14B42BG5WRNQNE/pdf-pages/cv-id-2.png</code>)
- Evidence: Indonesian PDF page 3 (local file: <code>/var/folders/56/2m6tn38j08j1ypyx86tvpz5c0000gn/T/no-mistakes-evidence/01M0J2FFW63T14B42BG5WRNQNE/pdf-pages/cv-id-3.png</code>)
- Evidence: Indonesian PDF page 4 (local file: <code>/var/folders/56/2m6tn38j08j1ypyx86tvpz5c0000gn/T/no-mistakes-evidence/01M0J2FFW63T14B42BG5WRNQNE/pdf-pages/cv-id-4.png</code>)
- Evidence: English PDF page 1 (print layout) (local file: <code>/var/folders/56/2m6tn38j08j1ypyx86tvpz5c0000gn/T/no-mistakes-evidence/01M0J2FFW63T14B42BG5WRNQNE/pdf-pages/cv-en-1.png</code>)
- Evidence: English PDF page 2 (local file: <code>/var/folders/56/2m6tn38j08j1ypyx86tvpz5c0000gn/T/no-mistakes-evidence/01M0J2FFW63T14B42BG5WRNQNE/pdf-pages/cv-en-2.png</code>)
- Evidence: English PDF page 3 (local file: <code>/var/folders/56/2m6tn38j08j1ypyx86tvpz5c0000gn/T/no-mistakes-evidence/01M0J2FFW63T14B42BG5WRNQNE/pdf-pages/cv-en-3.png</code>)
- Evidence: English PDF page 4 (local file: <code>/var/folders/56/2m6tn38j08j1ypyx86tvpz5c0000gn/T/no-mistakes-evidence/01M0J2FFW63T14B42BG5WRNQNE/pdf-pages/cv-en-4.png</code>)
<details>
<summary>Evidence: PDF MediaBox / page-count verification</summary>

`cv-id.pdf + cv-en.pdf: 4 pages each; MediaBox ≈ 595×842 pt (A4); no Banten/phone/appsco.id leaks; email present`

```text
{
  "cv-id.pdf": {
    "bytes": 291372,
    "pages": 4,
    "mediaboxes_unique": [
      [
        0.0,
        0.0,
        594.95996,
        841.91998
      ]
    ],
    "has_email": true,
    "has_present_or_sekarang": true,
    "leaks": [],
    "text_excerpt": "Riza Fahmi\n\nCo-Founder di Hacktiv8 Indonesia\nEMAIL\nGITHUB\nX\n\nrizafahmi@gmail.com\ngithub.com/rizafahmi\nx.com/rizafahmi22\n\nSITUS\nrizafahmi.com\nLINKEDIN linkedin.com/in/rizafahmi\nYOUTUBE youtube.com/rizafahmi\n\nRingkasan\nCo-Founder Hacktiv8, coding bootcamp yang saya rintis sejak 2016 untuk menjawab kelangkaan\ndeveloper yang menghambat tumbuhnya startup teknologi di Indonesia. Programnya imersif, 12 minggu,\ndan dirancang supaya orang dengan latar belakang teknis seadanya bisa sampai ke level junior\ndeveloper yang layak dibayar.\nSebelum itu saya menulis kode sejak 2003 dan naik pelan-pelan dari programmer ke team leader, head\nof R&D, sampai CTO \u2014 di portal berita, pendidikan online, dan civic tech. Sebagian besar pekerjaannya\nback-end, plus infrastruktur dan memimpin tim kecil.\nBagian yang pali",
    "page_count_pdftoppm": null
  },
  "cv-en.pdf": {
    "bytes": 290654,
    "pages": 4,
    "mediaboxes_unique": [
      [
        0.0,
        0.0,
        594.95996,
        841.91998
      ]
    ],
    "has_email": true,
    "has_present_or_sekarang": true,
    "leaks": [],
    "text_excerpt": "Riza Fahmi\n\nCo-Founder at Hacktiv8 Indonesia\nEMAIL\nGITHUB\nX\n\nrizafahmi@gmail.com\ngithub.com/rizafahmi\nx.com/rizafahmi22\n\nWEBSITE rizafahmi.com\nLINKEDIN linkedin.com/in/rizafahmi\nYOUTUBE youtube.com/rizafahmi\n\nSummary\nI co-founded Hacktiv8 in 2016 to close the developer hiring gap that was holding back Indonesia's tech\nstartups. It runs a 12-week immersive curriculum built so that people with little or no technical\nbackground can reach a paid junior developer role.\nBefore that I had been shipping software since 2003, moving from programmer to team leader, head of\nR&D, and CTO across news portals, online education, and civic technology. Mostly back-end work, plus\ninfrastructure and leading small teams.\nThe part I enjoy most is handing back what I learn: programming content since 2012, podcas",
    "page_count_pdftoppm": null
  }
}
```
</details>
<details>
<summary>Evidence: Acceptance checks (privacy, roles, discoverability)</summary>

```text
{
  "id": {
    "pdf_chars": 7468,
    "chrome_hits_in_pdf": [
      "Cari"
    ],
    "banned_skills_in_skills_section": [],
    "experience_orgs": [
      "Hacktiv8 Indonesia",
      "CitizenLab",
      "PT Haruka Edukasi Utama (HarukaEdu)",
      "PT. IONSOFT / IYAA.com (PT Indoportal Nusantara)",
      "PT. Okezone Indonesia",
      "Linuxindo",
      "PT. Ainetworks Indonesia"
    ],
    "experience_org_count": 7,
    "experience_role_count": 8,
    "ionsoft_entries": [
      "PT. IONSOFT / IYAA.com (PT Indoportal Nusantara)"
    ],
    "appsco_entries": [],
    "appscoast_present": true,
    "leaks": [],
    "email_in_pdf": true,
    "html_lang": "id",
    "pagefind_id": true,
    "pagefind_ignore": false,
    "present_word": true
  },
  "en": {
    "pdf_chars": 7280,
    "chrome_hits_in_pdf": [
      "Cari",
      "ENGLISH"
    ],
    "banned_skills_in_skills_section": [],
    "experience_orgs": [
      "Hacktiv8 Indonesia",
      "CitizenLab",
      "PT Haruka Edukasi Utama (HarukaEdu)",
      "PT. IONSOFT / IYAA.com (PT Indoportal Nusantara)",
      "PT. Okezone Indonesia",
      "Linuxindo",
      "PT. Ainetworks Indonesia"
    ],
    "experience_org_count": 7,
    "experience_role_count": 8,
    "ionsoft_entries": [
      "PT. IONSOFT / IYAA.com (PT Indoportal Nusantara)"
    ],
    "appsco_entries": [],
    "appscoast_present": true,
    "leaks": [],
    "email_in_pdf": true,
    "html_lang": "en",
    "pagefind_id": false,
    "pagefind_ignore": true,
    "present_word": true
  },
  "home": {
    "has_cv_link": true,
    "cv_link_snippet": "        <a href=\"/cv/\">CV</a>"
  },
  "dist/llms.txt": {
    "/cv/": true,
    "/cv/en/": true
  },
  "dist/sitemap.xml": {
    "/cv/": true,
    "/cv/en/": true
  }
}
```
</details>
<details>
<summary>Evidence: Indonesian PDF text extract</summary>

```text
Riza Fahmi
Co-Founder di Hacktiv8 Indonesia
EMAIL      rizafahmi@gmail.com                                  SITUS    rizafahmi.com
GITHUB     github.com/rizafahmi                                 LINKEDIN linkedin.com/in/rizafahmi
X          x.com/rizafahmi22                                    YOUTUBE youtube.com/rizafahmi



Ringkasan
Co-Founder Hacktiv8, coding bootcamp yang saya rintis sejak 2016 untuk menjawab kelangkaan
developer yang menghambat tumbuhnya startup teknologi di Indonesia. Programnya imersif, 12 minggu,
dan dirancang supaya orang dengan latar belakang teknis seadanya bisa sampai ke level junior
developer yang layak dibayar.

Sebelum itu saya menulis kode sejak 2003 dan naik pelan-pelan dari programmer ke team leader, head
of R&D, sampai CTO — di portal berita, pendidikan online, dan civic tech. Sebagian besar pekerjaannya
back-end, plus infrastruktur dan memimpin tim kecil.

Bagian yang paling saya nikmati adalah membagikan ulang apa yang saya pelajari: bikin konten
pemrograman sejak 2012, ngobrol di podcast sejak 2015, dan ikut mengurus komunitas sejak 2014.
Sekarang saya Google Developer Expert dan AWS Community Builder, dan sebagian besar tulisan serta
eksperimen saya berkutat di Elixir dan AI untuk ngoding.


Keahlian
BAHASA & RUNTIME               Elixir · JavaScript · TypeScript · Node.js · Bash
FRAMEWORK & TOOLING            Phoenix LiveView · OTP · Astro · Eleventy
DATA & INFRASTRUKTUR           SQLite · Turso · Local-first · Linux
AI & AGENTIC CODING            Anthropic API · Gemini API · Agentic coding · LLM evaluation
CARA KERJA                     Memimpin tim engineering · Perancangan kurikulum · Menulis teknis · Berbicara di
                               publik & workshop


Pengalaman Kerja
Hacktiv8 Indonesia
Co-Founder                                                                                November 2018 – Sekarang
Curriculum Director, Co-Founder                                                         Maret 2016 – November 2018
Coding bootcamp yang mengubah pemula jadi full-stack web developer dalam 12 minggu, termasuk mereka yang
nyaris tanpa latar belakang teknis, sampai layak masuk posisi junior developer berbayar.
  Menyusun dan menjalankan kurikulum imersif 12 minggu, dari nol sampai siap kerja.
  Menjaga tiga kesepakatan yang jadi budaya kerja: integritas, kebaikan, dan datang sebagai diri sendiri seutuhnya.

CitizenLab
Chief Technology Officer                                                              Agustus 2015 – Februari 2016
SaaS civic engagement: warga ikut merancang kotanya sendiri — mengusulkan ide, memberi dukungan, dan
pemerintah daerah menjalankan crowdvoting, misalnya untuk alokasi anggaran.
  Memegang hampir seluruh sisi teknis: back-end sebagai porsi terbesar, sebagian front-end, pemeliharaan, dan
  infrastruktur.
PT Haruka Edukasi Utama (HarukaEdu)
Developer                                                                      Juli 2013 – September 2015
Platform pendidikan online untuk perguruan tinggi.
  Merencanakan pengembangan, mengelola proyek dan tim developer.
  Membangun dan merawat platform, plus riset dan pengembangan untuk perbaikannya.

PT. IONSOFT / IYAA.com (PT Indoportal Nusantara)
Head of R&D                                                                     Februari 2012 – Juli 2013
Portal media dan layanan digital IYAA.com.
  Memimpin tim riset dan pengembangan.

PT. Okezone Indonesia
Team Leader Programmer                                                                         2011 – 2012
Memimpin dan mengembangkan portal berita serta aplikasi internal menggunakan PHP, XML, MySQL, dan
Django/Python.
  Mendesain ulang kanal-kanal portal.
  Mengembangkan www.sindonews.com.
  Membangun versi mobile sindonews dengan Django/Python.

Linuxindo
Programmer                                                                                     2007 – 2011
Mengembangkan dan menganalisis aplikasi web di berbagai framework PHP dan basis data.
  Sistem ERP berbasis web.
  Sistem MLM yang dirancang dengan UML.
  Sistem pelaporan fax server.
  Mengajar PostgreSQL.

PT. Ainetworks Indonesia
Programmer                                                                                2003 – Mei 2007
Aplikasi web, sebagian besar dengan PHP dan PostgreSQL.
  Sistem administrasi sekolah.
  Sistem SMS broadcast.
  Sistem absensi.
  Sistem delivery order.
  Sistem informasi rumah sakit.
  Sistem informasi perbankan.


Pendidikan
University of Indonesia
Magister (S2), Teknologi Informasi                                                             2008 – 2010

BINUS University
Sarjana (S1), Teknologi Informasi                                                              1999 – 2003


Mengajar & Komunitas
  Dosen di Universitas Budi Luhur.
  Google Developer Expert (GDE) dan AWS Community Builder.
  Organizer JakartaJS dan Meteor Jakarta.
  Merawat Awesome Speakers Indonesia, daftar terbuka developer yang berkenan diundang jadi narasumber.
Berbicara & Workshop
41 acara seminar · 19 workshop

Pengembangan perangkat lunak, komputasi awan, arsitektur, basis data, soft skill, dan topik teknologi
lain.

PANGGUNG TERPILIH
JSDay Indonesia 2019 (keynote) · DevFest GDG Jogja 2025 (workshop) · Singapore Elixir Meetup · GeekCamp ·
Lambda Jakarta

PERNAH BERKOLABORASI DENGAN
AWS Indonesia · BenQ Indonesia · Meta/Facebook · Google Indonesia · Domainesia · Niagahoster · Feedloop ·
DeepTech


Konten & Podcast
   Membuat konten pemrograman sejak 2012
   Memandu podcast sejak 2015
   Berkontribusi ke komunitas pemrograman sejak 2014

KANAL
   Ngobrolin Web BERJALAN — Podcast mingguan yang membahas segala hal tentang web.
   YouTube BERJALAN — Tutorial dan sesi livestream ngoding bareng seputar AI, Elixir, dan web.
   Ceritanya Developer ARSIP — Podcast.
   Hikayat Punggawa Teknologi ARSIP — Serial podcast.
   AppsCoast ARSIP — Podcast tentang startup teknologi Indonesia.

KURSUS
   SvelteJS — Membangun aplikasi web donasi online dan integrasi payment gateway.
   Struktur Data dengan JavaScript — Fundamental struktur data lewat JavaScript.
   PWA dengan React — Menerapkan progressive web app dengan React.


Karya Terpilih
OPEN SOURCE
   slopcase Elixir · Phoenix LiveView · SQLite
   mbb Elixir · CLI · Anthropic
   gemini-for-web-dev Node.js · Gemini API · Turso
   workspresso Astro · Node.js · SQLite
   ai-workshop-material Workshop · JavaScript · LLM
   makan-dimana Astro · TypeScript · Local-first
   Ngobrolin Web Astro · TypeScript · Podcast
   notable Elixir · Phoenix LiveView · SQLite
   samarin Astro · TypeScript · Local-first
   clawdex Elixir · OTP · Telegram
   evalcode Elixir · Bash · LLM Eval
   maal Astro · TypeScript · Zakat
   Balap Kode Elixir · Phoenix LiveView · AI
LAINNYA
  Carikerja — Daftar developer yang terdampak COVID-19, supaya lebih mudah ditemukan perusahaan.
  Awesome Speakers Indonesia — Daftar terbuka developer Indonesia yang berkenan jadi narasumber.


Penghargaan & Publikasi
SERTIFIKASI 2023 Southeast Asia EdTech 50

PENGHARGAAN Most Inspiring Lead

PUBLIKASI
  Reactive Programming Made Simple
  How I Met 10 Entrepreneurs In Asia And What Can We Learn From Them
  Startup Talks In Asia: Candid Interview With 10 Asian Start-up Founders About Their Entrepreneurial Journey
  Meteor Introduction at TokoPedia Tech A Break #4


Bahasa
BAHASA INDONESIA            Penutur asli / dwibahasa
BAHASA INGGRIS              Kemampuan kerja profesional

Diperbarui Agustus 2026

```
</details>
- Evidence: English PDF text extract (local file: <code>/var/folders/56/2m6tn38j08j1ypyx86tvpz5c0000gn/T/no-mistakes-evidence/01M0J2FFW63T14B42BG5WRNQNE/cv-en-full.txt</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `src/_data/cv.js:250` - English Okezone highlight reads &#34;Redesigned the portal canals.&#34; while the Indonesian source is &#34;Mendesain ulang kanal-kanal portal.&#34; In a media-portal context, &#34;kanal&#34; means channels/sections, not water canals — so the EN line is a mistranslation on the print-ready English CV. Intent requires facts from the reconciled sources without inventing beyond them; confirm the LinkedIn/export wording and replace with the accurate English (likely &#34;portal channels&#34;).

🔧 Fix: Fix portal channels wording and channel status
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --test test/cv.test.js test/cv-page.test.js`
- <code>`ELEVENTY_ENV=prod pnpm exec eleventy` then served `dist/` on `:8765`</code>
- <code>Manual acceptance checks on built HTML + print PDFs (no Banten/phone/tel:/appsco.id; 7 employers/8 roles; IONSOFT/IYAA merged; AppsCO absent; AppsCoast kept; banned skills out of skills section; email + profile URLs present; id `data-pagefind-body` / en `data-pagefind-ignore`; home secondary link `Uses`/`Now`/`CV`; `/cv/` + `/cv/en/` in sitemap.xml and llms.txt)</code>
- <code>Headless Chrome print-to-PDF + screenshots for `/cv/`, `/cv/en/`, and homepage; `pdftoppm`/`pdftotext` on both PDFs</code>
- <code>`pnpm run clean` to remove worktree `dist/` after evidence capture</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `CLAUDE.md:39` - CLAUDE.md still carries a conflicting Design Context (&#34;The Minimalist Foundry&#34;, 75ch, JavaScript Standard Style) that duplicates and contradicts the owners in DESIGN.md and AGENTS.md (Neo-Acid Gallery, 65ch, Biome). This change did not introduce that conflict; consolidating CLAUDE.md into a short pointer to AGENTS.md/DESIGN.md is a worthwhile follow-up outside this pass&#39;s scope.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
