### PR TITLE
fix: retire the AWS Community Builder claim

### DIFF
--- a/src/_data/cv.js
+++ b/src/_data/cv.js
@@ -35,13 +35,15 @@
  *   Proyek open source di halaman CV diambil langsung dari src/_data/karya.js,
  *   tidak disalin ke sini. Tambah proyek di sana, CV ikut terisi.
  *
- * STATUS KANAL
- *   Tiap entri di `content.channels` wajib punya `status`: "current" atau
- *   "retired". Label yang tampil (Berjalan/Running, Arsip/Archive) hidup di
- *   template, bukan di sini — jadi membalik status satu kanal cukup mengganti
- *   satu kata di file ini. Halaman menampilkan yang masih berjalan dulu,
- *   lalu yang sudah diarsip, dengan urutan relatif di dalam tiap kelompok
- *   tetap seperti di sini.
+ * STATUS (KANAL & KREDENSIAL)
+ *   Label `status` ("current" / "retired") dipakai bersama: map-nya satu
+ *   (`L.status` di cv_body.njk → Berjalan/Running, Arsip/Archive), jangan
+ *   invent marker lain. Tiap entri di `content.channels` WAJIB punya status;
+ *   halaman menampilkan yang masih berjalan dulu, lalu yang diarsip, dengan
+ *   urutan relatif di dalam tiap kelompok tetap seperti di sini. Entri di
+ *   `teaching` BOLEH opsional membawa `status: "retired"` untuk kredensial
+ *   yang sudah tidak aktif (tetap dicantumkan karena pernah digapai) — tanpa
+ *   tanggal masa aktif; podcast yang diarsip juga tanpa tanggal.
  */
 
 export default {

--- a/src/_data/cv.js
+++ b/src/_data/cv.js
@@ -117,8 +117,8 @@ export default {
       en: "Before that I had been shipping software since 2003, moving from programmer to team leader, head of R&D, and CTO across news portals, online education, and civic technology. Mostly back-end work, plus infrastructure and leading small teams.",
     },
     {
-      id: "Bagian yang paling saya nikmati adalah membagikan ulang apa yang saya pelajari: bikin konten pemrograman sejak 2012, ngobrol di podcast sejak 2015, dan ikut mengurus komunitas sejak 2014. Sekarang saya Google Developer Expert dan AWS Community Builder, dan sebagian besar tulisan serta eksperimen saya berkutat di Elixir dan AI untuk ngoding.",
-      en: "The part I enjoy most is handing back what I learn: programming content since 2012, podcasting since 2015, and community organising since 2014. I am a Google Developer Expert and an AWS Community Builder, and most of my current writing and side projects sit where Elixir meets AI-assisted development.",
+      id: "Bagian yang paling saya nikmati adalah membagikan ulang apa yang saya pelajari: bikin konten pemrograman sejak 2012, ngobrol di podcast sejak 2015, dan ikut mengurus komunitas sejak 2014. Sekarang saya Google Developer Expert, pernah juga jadi AWS Community Builder, dan sebagian besar tulisan serta eksperimen saya berkutat di Elixir dan AI untuk ngoding.",
+      en: "The part I enjoy most is handing back what I learn: programming content since 2012, podcasting since 2015, and community organising since 2014. I am a Google Developer Expert and a former AWS Community Builder, and most of my current writing and side projects sit where Elixir meets AI-assisted development.",
     },
   ],
 
@@ -323,8 +323,13 @@ export default {
       en: "Lecturer at Universitas Budi Luhur.",
     },
     {
-      id: "Google Developer Expert (GDE) dan AWS Community Builder.",
-      en: "Google Developer Expert (GDE) and AWS Community Builder.",
+      id: "Google Developer Expert (GDE).",
+      en: "Google Developer Expert (GDE).",
+    },
+    {
+      id: "AWS Community Builder",
+      en: "AWS Community Builder",
+      status: "retired",
     },
     {
       id: "Organizer JakartaJS dan Meteor Jakarta.",

--- a/src/_includes/cv_body.njk
+++ b/src/_includes/cv_body.njk
@@ -38,7 +38,7 @@
   awards: { id: "Penghargaan", en: "Honours" },
   publications: { id: "Publikasi", en: "Publications" },
   updated: { id: "Diperbarui", en: "Updated" },
-  channelStatus: {
+  status: {
     current: { id: "Berjalan", en: "Running" },
     retired: { id: "Arsip", en: "Archive" }
   }
@@ -127,7 +127,7 @@
     <h2>{{ L.teaching | translate(lang) }}</h2>
     <ul class="cv-list">
       {%- for item in cv.teaching %}
-      <li>{{ item | translate(lang) }}</li>
+      <li>{{ item | translate(lang) }}{% if item.status %} <span class="cv-status">{{ L.status[item.status] | translate(lang) }}</span>{% endif %}</li>
       {%- endfor %}
     </ul>
   </section>
@@ -161,7 +161,7 @@
       {%- for channel in cv.content.channels | orderedChannels %}
       <li>
         <a href="{{ channel.url }}" rel="noopener">{{ channel.name | translate(lang) }}</a>
-        <span class="cv-status">{{ L.channelStatus[channel.status] | translate(lang) }}</span>
+        <span class="cv-status">{{ L.status[channel.status] | translate(lang) }}</span>
         — {{ channel.note | translate(lang) }}
       </li>
       {%- endfor %}

--- a/src/now.njk
+++ b/src/now.njk
@@ -11,7 +11,7 @@ eleventyExcludeFromCollections: true
 <h3>🎯 Fokus Utama</h3>
 <ul>
   <li><strong>Co-Founder di <a href="https://hacktiv8.com" target="_blank" rel="noopener noreferrer">HACKTIV8</a></strong> — Coding bootcamp yang sudah berjalan sejak 2016</li>
-  <li><strong>Komunitas</strong> — Aktif sebagai Google Developer Expert (GDE) dan AWS Community Builder</li>
+  <li><strong>Komunitas</strong> — Aktif sebagai Google Developer Expert (GDE)</li>
 </ul>
 
 <h3>📚 Sedang Dipelajari</h3>
@@ -50,4 +50,4 @@ eleventyExcludeFromCollections: true
 
 <p><em>Ini adalah <a href="https://nownownow.com/about" target="_blank" rel="noopener noreferrer">now page</a>. Kamu juga sebaiknya bikin!</em></p>
 
-<p><em>Terakhir diperbarui: Februari 2026</em></p>
+<p><em>Terakhir diperbarui: Agustus 2026</em></p>

--- a/test/cv-page.test.js
+++ b/test/cv-page.test.js
@@ -104,10 +104,11 @@ test("profile links read as their own address, so they survive being printed", (
 
 test("both languages render a visible status for every content channel", () => {
   const channelCount = cv.content.channels.length;
+  const retiredTeaching = cv.teaching.filter((item) => item.status === "retired").length;
   for (const [lang, html] of Object.entries(pages)) {
     assert.equal(
       count(html, /class="cv-status"/g),
-      channelCount,
+      channelCount + retiredTeaching,
       `${lang} must show a status badge for every channel`,
     );
   }
@@ -136,4 +137,25 @@ test("current channels render before retired ones on both language pages", () =>
 
 test("channel status count stays aligned across languages", () => {
   assert.equal(count(pages.en, /class="cv-status"/g), count(pages.id, /class="cv-status"/g));
+});
+
+// The captain stopped being an AWS Community Builder in July 2026. The credential
+// was genuinely earned so it stays on the record — but nothing on the page may
+// still assert it in the present tense.
+test("the CV marks the AWS credential as past, in prose and in structure", () => {
+  for (const [lang, html] of Object.entries(pages)) {
+    assert.match(html, /AWS Community Builder/, `${lang} should keep the earned credential`);
+    assert.match(html, /Google Developer Expert/, `${lang} should keep the current credential`);
+  }
+
+  // Prose: a badge cannot fix a sentence, so the summary has to say it.
+  assert.match(pages.id, /pernah\s+\w*\s*(jadi|menjadi)\s+AWS Community Builder/i);
+  assert.match(pages.en, /former AWS Community Builder/i);
+  assert.doesNotMatch(pages.id, /saya Google Developer Expert dan AWS Community Builder/);
+  assert.doesNotMatch(pages.en, /a Google Developer Expert and an AWS Community Builder/);
+
+  // Structure: the credentials line reuses the same retired marker as the
+  // archived podcasts rather than inventing a second convention.
+  assert.match(pages.id, /AWS Community Builder[^<]*<span class="cv-status">Arsip<\/span>/);
+  assert.match(pages.en, /AWS Community Builder[^<]*<span class="cv-status">Archive<\/span>/);
 });

--- a/test/now-page.test.js
+++ b/test/now-page.test.js
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const source = await readFile("src/now.njk", "utf8");
+
+// The captain stopped being an AWS Community Builder in July 2026. The whole
+// point of the removal is that the claim must not come back on a later edit.
+test("the now page no longer claims a retired credential", () => {
+  assert.doesNotMatch(source, /AWS Community Builder/i);
+});
+
+test("the now page still lists the credential that is current", () => {
+  assert.match(source, /Google Developer Expert \(GDE\)/);
+});
+
+// A /now page whose own stamp is stale undercuts the premise of the page.
+test("the now page carries a hand-maintained last-updated stamp", () => {
+  assert.match(source, /Terakhir diperbarui: [A-Z][a-z]+ \d{4}/);
+});


### PR DESCRIPTION
## Intent

The captain stopped being an AWS Community Builder in July 2026 (today is 21 August 2026). Reflect that one fact across the site in one change.

/now (src/now.njk): drop the AWS Community Builder claim entirely - a /now page is by definition what is current, so an inactive credential does not belong there. Google Developer Expert stays: it is still current. The resulting Indonesian sentence had to read naturally, matching the register of the surrounding list items, not like a phrase surgically removed. Also fix the page's own stale stamp 'Terakhir diperbarui: Februari 2026'. Deliberate decision: the stamp stays HAND-TYPED (updated to Agustus 2026) rather than derived from site.buildTime, because a rebuild is not an edit and a build-derived date would overstate freshness. The captain explicitly approved that call - do not flag the hardcoded date as something that should be automated.

CV (revised captain instruction, superseding an earlier 'leave the CV alone' decision): 'for CV, keep the AWS Community Builders, but no longer active.' So in src/_data/cv.js the credential is KEPT, not deleted - it was genuinely earned and belongs on the record - but nothing may still assert it in the present tense. Two places: (1) the third summary paragraph, prose in both languages, reworded independently per language rather than translating one into the other (id: 'Sekarang saya Google Developer Expert, pernah juga jadi AWS Community Builder...'; en: '...a Google Developer Expert and a former AWS Community Builder...'); (2) the community/credentials line in cv.teaching, split into a current GDE entry and a separate 'AWS Community Builder' entry carrying status: 'retired', rendered with the EXISTING retired-marker mechanism already used for archived podcasts (span.cv-status showing 'Arsip'/'Archive'). Reusing that convention was explicitly required - inventing a second competing way to mark something ended was ruled out. The label map in src/_includes/cv_body.njk was renamed channelStatus -> status because it now covers more than channels.

No dates on the retired credential: the archived podcasts carry none either, and the captain does not have the period - inventing a year was explicitly ruled out.

Tests: added test/now-page.test.js guarding that the retired claim cannot come back to /now and that GDE plus a last-updated stamp remain; extended test/cv-page.test.js with a test asserting the CV keeps both credentials, marks AWS as past in prose in each language, and renders it with the shared Arsip/Archive badge; updated the existing badge-count assertion to account for the retired teaching entry.

Verified against built HTML for /now/, /cv/ and /cv/en/, not just source. /cv/ A4 pagination checked before and after via headless print: 4 pages both ways. pnpm test (102 pass) and pnpm run build with site audit pass. Note: biome flags only the harness-injected untracked .claude/settings.local.json, which is not part of this change.

## What Changed

- Removes the AWS Community Builder claim from `/now` and updates the hand-typed last-updated stamp to Agustus 2026, while keeping Google Developer Expert as the current community credential.
- Keeps AWS Community Builder on the bilingual CV as a past credential: summary prose is past tense in both languages, and teaching lists a separate retired entry that reuses the shared Arsip/Archive status badge (via the renamed `status` label map).
- Adds `/now` regression coverage and extends CV page tests so the credential stays on record, stays past tense in prose, and keeps rendering with the existing retired marker.

## Risk Assessment

✅ Low: Narrow, intent-aligned content update that reuses the existing retired-status marker with no remaining present-tense AWS Community Builder claims in changed surfaces.

## Testing

Ran the focused now and CV page tests after install, built the site, and captured headless screenshots of the live /now and bilingual CV surfaces; all intent checks passed and transient dist/server artifacts were cleaned.

- Evidence: /now komunitas line shows GDE only (local file: <code>/var/folders/56/2m6tn38j08j1ypyx86tvpz5c0000gn/T/no-mistakes-evidence/01M0J5HKZC807D7XTVMPJ8TW67/now-komunitas-line.png</code>)
- Evidence: /now last-updated stamp Agustus 2026 (local file: <code>/var/folders/56/2m6tn38j08j1ypyx86tvpz5c0000gn/T/no-mistakes-evidence/01M0J5HKZC807D7XTVMPJ8TW67/now-updated-stamp.png</code>)
- Evidence: /now full page (local file: <code>/var/folders/56/2m6tn38j08j1ypyx86tvpz5c0000gn/T/no-mistakes-evidence/01M0J5HKZC807D7XTVMPJ8TW67/now-full.png</code>)
- Evidence: /cv ID summary with pernah juga jadi AWS (local file: <code>/var/folders/56/2m6tn38j08j1ypyx86tvpz5c0000gn/T/no-mistakes-evidence/01M0J5HKZC807D7XTVMPJ8TW67/cv-id-summary-former.png</code>)
- Evidence: /cv ID AWS Community Builder Arsip badge (local file: <code>/var/folders/56/2m6tn38j08j1ypyx86tvpz5c0000gn/T/no-mistakes-evidence/01M0J5HKZC807D7XTVMPJ8TW67/cv-id-aws-retired-badge.png</code>)
- Evidence: /cv ID teaching section (local file: <code>/var/folders/56/2m6tn38j08j1ypyx86tvpz5c0000gn/T/no-mistakes-evidence/01M0J5HKZC807D7XTVMPJ8TW67/cv-id-teaching-section.png</code>)
- Evidence: /cv/en summary with former AWS Community Builder (local file: <code>/var/folders/56/2m6tn38j08j1ypyx86tvpz5c0000gn/T/no-mistakes-evidence/01M0J5HKZC807D7XTVMPJ8TW67/cv-en-summary-former.png</code>)
- Evidence: /cv/en AWS Community Builder Archive badge (local file: <code>/var/folders/56/2m6tn38j08j1ypyx86tvpz5c0000gn/T/no-mistakes-evidence/01M0J5HKZC807D7XTVMPJ8TW67/cv-en-aws-retired-badge.png</code>)
- Evidence: /cv/en teaching section (local file: <code>/var/folders/56/2m6tn38j08j1ypyx86tvpz5c0000gn/T/no-mistakes-evidence/01M0J5HKZC807D7XTVMPJ8TW67/cv-en-teaching-section.png</code>)
<details>
<summary>Evidence: Built HTML excerpts for /now, /cv, /cv/en</summary>

<code>/now: GDE only + Terakhir diperbarui: Agustus 2026; no AWS.&#10;/cv: &#39;pernah juga jadi AWS Community Builder&#39; + &lt;span class=&#34;cv-status&#34;&gt;Arsip&lt;/span&gt;.&#10;/cv/en: &#39;former AWS Community Builder&#39; + &lt;span class=&#34;cv-status&#34;&gt;Archive&lt;/span&gt;.</code>

```text
=== /now/ (built dist/now/index.html) ===
<li><strong>Komunitas</strong> — Aktif sebagai Google Developer Expert (GDE)</li>
<p><em>Terakhir diperbarui: Agustus 2026</em></p>
(AWS Community Builder: absent from page)

=== /cv/ (built dist/cv/index.html) ===
<p>... Sekarang saya Google Developer Expert, pernah juga jadi AWS Community Builder, ...</p>
<li>Google Developer Expert (GDE).</li>
<li>AWS Community Builder <span class="cv-status">Arsip</span></li>

=== /cv/en/ (built dist/cv/en/index.html) ===
<p>... I am a Google Developer Expert and a former AWS Community Builder, ...</p>
<li>Google Developer Expert (GDE).</li>
<li>AWS Community Builder <span class="cv-status">Archive</span></li>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --test test/now-page.test.js test/cv-page.test.js`
- <code>`pnpm exec eleventy` then served `dist/` on `:3456`</code>
- <code>Verified built HTML for `/now/`, `/cv/`, `/cv/en/` (no AWS on /now; past-tense prose + Arsip/Archive badge on CV)</code>
- `Headless Chrome screenshots of /now komunitas line + stamp and CV id/en summary + teaching badge`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
